### PR TITLE
Separate plugin config file

### DIFF
--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -41,22 +41,23 @@ exports.generate = function(binary, next){
   documents.readmeMd    = String(fs.readFileSync(binary.paths.actionheroRoot + '/bin/templates/README.md'));
 
   // Add matching package.json dependencies to the dedicated plugins config file
+  var dep;
   var pluginsArrayContents="";
-  if(typeof(JSON.parse(documents.packageJson).dependencies)==="object")
+  if(typeof(JSON.parse(documents.packageJson).dependencies)==="object" && documents.configApiJs.packageJSONDependencyNameRegexForPlugins)
   {
-    JSON.parse(documents.packageJson).dependencies.forEach(function(dep)
+    for(dep in JSON.parse(documents.packageJson).dependencies)
     {
-      if(dep.match(documents.configApiJs.packageJSONDependencyNameRegexForPlugins))
+      if(JSON.parse(documents.packageJson).dependencies.hasOwnProperty(dep))
       {
-        pluginsArrayContents+dep.trim()+"\n";
+        if(dep.match(documents.configApiJs.packageJSONDependencyNameRegexForPlugins))
+        {
+          pluginsArrayContents+=dep.trim()+"\n";  
+        }
       }
-    });
+    }
   }
-  documents.configPluginsJs = documents.configPluginsJs.replace('%%REPLACE%%', pluginsArrayContents);
 
-console.dir(documents.configPluginsJs);
-process.exit();
-
+  documents.configPluginsJs = String(documents.configPluginsJs).replace('%%REPLACE%%', pluginsArrayContents);
 
   //////// LOGIC ////////
 
@@ -68,6 +69,7 @@ process.exit();
     '/pids',
     '/config',
     '/config/servers',
+    '/config/plugins',
     '/initializers',
     '/log',
     '/servers',

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -16,7 +16,7 @@ exports.generate = function(binary, next){
     configStatsJs               : '/config/stats.js',
     configTasksJs               : '/config/tasks.js',
     configErrorsJs              : '/config/errors.js',
-    configRoutesJs              : '/config/routes.js',    
+    configRoutesJs              : '/config/routes.js',
     configSocketJs              : '/config/servers/socket.js',
     configWebJs                 : '/config/servers/web.js',
     configWebsocketJs           : '/config/servers/websocket.js',
@@ -28,7 +28,7 @@ exports.generate = function(binary, next){
     publicChat                   : '/public/chat.html',
     publicLogo                   : '/public/logo/actionhero.png',
     publicCss                    : '/public/css/actionhero.css',
-    exampleTest                  : '/test/template.js.example',
+    exampleTest                  : '/test/template.js.example'
   }
   for(var name in oldFileMap){
     documents[name] = fs.readFileSync(binary.paths.actionheroRoot + oldFileMap[name]);
@@ -41,24 +41,24 @@ exports.generate = function(binary, next){
   documents.readmeMd    = String(fs.readFileSync(binary.paths.actionheroRoot + '/bin/templates/README.md'));
 
   // Add plugins (from --plugins argument) to the dedicated plugins config file
-  var pluginsArrayContents="";
+  var pluginsArrayContents='';
   if(binary.argv.plugins)
   {
-    var pluginsArg=binary.argv.plugins.split(",");
+    var pluginsArg=binary.argv.plugins.split(',');
 
     pluginsArg.forEach(function(dep)
     {
       // if(dep.match(/^ah-.*-plugin$/g)!==null)
-      if(typeof(dep)==="string")
+      if(typeof(dep)==='string')
       {
-        pluginsArrayContents+="\""+dep.trim()+"\",\n";
+        pluginsArrayContents+='"'+dep.trim()+'",\n';
       }
     });
 
     pluginsArrayContents=pluginsArrayContents.trim();
   }
 
-  documents.configPluginsJs = String(documents.configPluginsJs).replace('%%REPLACE%%', pluginsArrayContents);
+  documents.configPluginsJs = String(documents.configPluginsJs).replace('\'%%REPLACE%%\'', pluginsArrayContents);
 
   //////// LOGIC ////////
 
@@ -79,7 +79,7 @@ exports.generate = function(binary, next){
     '/public/css',
     '/public/logo',
     '/tasks',
-    '/test',
+    '/test'
   ].forEach(function(dir){
     binary.utils.createDirSafely(binary.paths.projectRoot + dir);
   });
@@ -106,7 +106,7 @@ exports.generate = function(binary, next){
     '/public/logo/actionhero.png'                   : 'publicLogo',
     '/README.md'                                    : 'readmeMd',
     '/gruntfile.js'                                 : 'gruntfile',
-    '/test/example.js'                              : 'exampleTest',
+    '/test/example.js'                              : 'exampleTest'
   }
   for(var file in newFileMap){
     binary.utils.createFileSafely(binary.paths.projectRoot + file, documents[newFileMap[file]]);
@@ -118,6 +118,6 @@ exports.generate = function(binary, next){
   binary.log('you may need to run `npm install` to install some dependancies');
   binary.log('run \'npm start\' to start your server');
 
-  next(); 
+  next();
 
 }

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -40,21 +40,22 @@ exports.generate = function(binary, next){
   documents.packageJson = documents.packageJson.replace('%%versionNumber%%', AHversionNumber);
   documents.readmeMd    = String(fs.readFileSync(binary.paths.actionheroRoot + '/bin/templates/README.md'));
 
-  // Add matching package.json dependencies to the dedicated plugins config file
-  var dep;
+  // Add plugins (from --plugins argument) to the dedicated plugins config file
   var pluginsArrayContents="";
-  if(typeof(JSON.parse(documents.packageJson).dependencies)==="object" && documents.configApiJs.packageJSONDependencyNameRegexForPlugins)
+  if(binary.argv.plugins)
   {
-    for(dep in JSON.parse(documents.packageJson).dependencies)
+    var pluginsArg=binary.argv.plugins.split(",");
+
+    pluginsArg.forEach(function(dep)
     {
-      if(JSON.parse(documents.packageJson).dependencies.hasOwnProperty(dep))
+      // if(dep.match(/^ah-.*-plugin$/g)!==null)
+      if(typeof(dep)==="string")
       {
-        if(dep.match(documents.configApiJs.packageJSONDependencyNameRegexForPlugins))
-        {
-          pluginsArrayContents+=dep.trim()+"\n";  
-        }
+        pluginsArrayContents+="\""+dep.trim()+"\",\n";
       }
-    }
+    });
+
+    pluginsArrayContents=pluginsArrayContents.trim();
   }
 
   documents.configPluginsJs = String(documents.configPluginsJs).replace('%%REPLACE%%', pluginsArrayContents);

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -10,6 +10,7 @@ exports.generate = function(binary, next){
 
   var oldFileMap = {
     configApiJs                 : '/config/api.js',
+    configPluginsJs             : '/bin/templates/plugins.js',
     configLoggerJs              : '/config/logger.js',
     configRedisJs               : '/config/redis.js',
     configStatsJs               : '/config/stats.js',
@@ -39,6 +40,24 @@ exports.generate = function(binary, next){
   documents.packageJson = documents.packageJson.replace('%%versionNumber%%', AHversionNumber);
   documents.readmeMd    = String(fs.readFileSync(binary.paths.actionheroRoot + '/bin/templates/README.md'));
 
+  // Add matching package.json dependencies to the dedicated plugins config file
+  var pluginsArrayContents="";
+  if(typeof(JSON.parse(documents.packageJson).dependencies)==="object")
+  {
+    JSON.parse(documents.packageJson).dependencies.forEach(function(dep)
+    {
+      if(dep.match(documents.configApiJs.packageJSONDependencyNameRegexForPlugins))
+      {
+        pluginsArrayContents+dep.trim()+"\n";
+      }
+    });
+  }
+  documents.configPluginsJs = documents.configPluginsJs.replace('%%REPLACE%%', pluginsArrayContents);
+
+console.dir(documents.configPluginsJs);
+process.exit();
+
+
   //////// LOGIC ////////
 
   binary.log('Generating a new actionhero project...');
@@ -65,6 +84,7 @@ exports.generate = function(binary, next){
   // make files
   var newFileMap = {
     '/config/api.js'                                : 'configApiJs',
+    '/config/plugins.js'                            : 'configPluginsJs',
     '/config/logger.js'                             : 'configLoggerJs',
     '/config/redis.js'                              : 'configRedisJs',
     '/config/stats.js'                              : 'configStatsJs',

--- a/bin/templates/plugins.js
+++ b/bin/templates/plugins.js
@@ -1,12 +1,14 @@
-exports.default = {
-	general: function(api)
-	{
-		return {
-			plugins: [
-			// this is a list of plugin names
-			// plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
-			%%REPLACE%%
-			]
-		};
-	}
+'use strict';
+
+exports['default'] = {
+  general: function(api)
+  {
+    return {
+      plugins: [
+        // this is a list of plugin names
+        // plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
+        '%%REPLACE%%' // Used a string here to avoid JS formatting violations
+      ]
+    };
+  }
 };

--- a/bin/templates/plugins.js
+++ b/bin/templates/plugins.js
@@ -1,0 +1,12 @@
+exports.default = {
+	general: function(api)
+	{
+		return {
+			plugins: [
+			// this is a list of plugin names
+			// plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
+			%%REPLACE%%
+			]
+		};
+	};
+};

--- a/bin/templates/plugins.js
+++ b/bin/templates/plugins.js
@@ -8,5 +8,5 @@ exports.default = {
 			%%REPLACE%%
 			]
 		};
-	};
+	}
 };

--- a/config/api.js
+++ b/config/api.js
@@ -43,8 +43,6 @@ exports.default = {
         'initializer': [ __dirname + '/../initializers' ] ,
         'plugin':      [ __dirname + '/../node_modules' ] 
       },
-      // Regex to match package.json dependencies to try to automatically detect actionhero plugins
-      packageJSONDependencyNameRegexForPlugins:/^ah-[a-z\-]+-plugin$/g,
       // hash containing chat rooms you wish to be created at server boot
       startingChatRooms: {
         // format is {roomName: {authKey, authValue}}

--- a/config/api.js
+++ b/config/api.js
@@ -43,11 +43,8 @@ exports.default = {
         'initializer': [ __dirname + '/../initializers' ] ,
         'plugin':      [ __dirname + '/../node_modules' ] 
       },
-      // list of actionhero plugins you want to load
-      plugins: [
-        // this is a list of plugin names
-        // plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
-      ],
+      // Regex to match package.json dependencies to try to automatically detect actionhero plugins
+      packageJSONDependencyNameRegexForPlugins:/^ah-[a-z\-]+-plugin$/g,
       // hash containing chat rooms you wish to be created at server boot
       startingChatRooms: {
         // format is {roomName: {authKey, authValue}}

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,0 +1,11 @@
+exports.default = {
+	general: function(api)
+	{
+		return {
+			plugins: [
+			// this is a list of plugin names
+			// plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
+			]
+		};
+	}
+};

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,11 +1,11 @@
 exports.default = {
-	general: function(api)
-	{
-		return {
-			plugins: [
-			// this is a list of plugin names
-			// plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
-			]
-		};
-	}
+  general: function(api)
+  {
+    return {
+      plugins: [
+        // this is a list of plugin names
+        // plugin still need to be included in `package.json` or the path defined in `api.config.general.paths.plugin`
+      ]
+    };
+  }
 };

--- a/test/actions/cacheTest.js
+++ b/test/actions/cacheTest.js
@@ -6,6 +6,12 @@ var api;
 describe('Action: Cache Test', function(){
 
   before(function(done){
+
+
+// NC TMP
+console.dir(actionhero);
+
+
     actionhero.start(function(err, a){
       api = a;
       done();

--- a/test/actions/cacheTest.js
+++ b/test/actions/cacheTest.js
@@ -6,12 +6,6 @@ var api;
 describe('Action: Cache Test', function(){
 
   before(function(done){
-
-
-// NC TMP
-console.dir(actionhero);
-
-
     actionhero.start(function(err, a){
       api = a;
       done();


### PR DESCRIPTION
Hi Evan

Here's my PR WRT https://github.com/evantahler/actionhero/issues/512. It's a branch obviously, I thought that'd likely be best but I can merge into `master` if you prefer.

I hope i've done the right thing but please let me know if you don't think I have. It's tricky to test without being able to install via NPM but from what I can see, the plugins are loading correctly.

I wasn't sure whether to add to `package.json` `install` string or not but this PR includes the option for an argument on the `generate` method to add plugins to the new `config/plugins.js` file. The arg is `--plugins` and just uses the existing `binary.argv` object. My thinking is that this doesn't break any existing script people may be using and does not add plugins by default but does allow programmatic addition of plugins via a little shell scripting or similar.

Hope that's all OK anyway. If so, I can perhaps update the `gh-pages` branch to include the info on the flag and the config file.

Cheers
Neil

