### PR TITLE
Chat Callbacks

### DIFF
--- a/config/api.js
+++ b/config/api.js
@@ -52,7 +52,8 @@ exports.default = {
       startingChatRooms: {
         // format is {roomName: {authKey, authValue}}
         //'secureRoom': {authorized: true},
-        'defaultRoom': {}
+        'defaultRoom': {},
+        'anotherRoom': {},
       }
     }
   }
@@ -72,7 +73,6 @@ exports.test = {
       startingChatRooms: {
         'defaultRoom': {},
         'otherRoom': {},
-        'secureRoom': {authorized: true}
       },
     }
   }

--- a/config/errors.js
+++ b/config/errors.js
@@ -102,10 +102,6 @@ exports.default = {
         return 'this room has been deleted';
       },
 
-      connectionNotAuthorized: function(room){
-        return 'not authorized to join room';
-      },
-
       connectionRoomNotExist: function(room){
         return 'room does not exist';
       },

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -9,11 +9,11 @@ module.exports = {
     api.chatRoom.keys = {
       rooms:   'actionhero:chatRoom:rooms',
       members: 'actionhero:chatRoom:members:',
-      auth:    'actionhero:chatRoom:auth'
     }
     api.chatRoom.messageChannel     = '/actionhero/chat/chat';
     api.chatRoom.joinCallbacks      = {};
     api.chatRoom.leaveCallbacks     = {};
+    api.chatRoom.sayCallbacks       = {};
 
     api.chatRoom.addJoinCallback = function(func, priority){
       if(!priority) priority = api.config.general.defaultMiddlewarePriority;
@@ -27,6 +27,13 @@ module.exports = {
       priority = Number(priority); // ensure priority is numeric
       if(!api.chatRoom.leaveCallbacks[priority]) api.chatRoom.leaveCallbacks[priority] = [];
       return api.chatRoom.leaveCallbacks[priority].push(func);
+    }
+
+    api.chatRoom.addSayCallback = function(func, priority){
+      if(!priority) priority = api.config.general.defaultMiddlewarePriority;
+      priority = Number(priority); // ensure priority is numeric
+      if(!api.chatRoom.sayCallbacks[priority]) api.chatRoom.sayCallbacks[priority] = [];
+      return api.chatRoom.sayCallbacks[priority].push(func);
     }
 
     api.chatRoom.broadcast = function(connection, room, message, callback){
@@ -60,9 +67,11 @@ module.exports = {
       for(var i in api.connections.connections){
         var thisConnection = api.connections.connections[i];
         if(thisConnection.canChat === true){
-          if(thisConnection.rooms.indexOf(message.connection.room) > -1){
-            if(message.connection === undefined || thisConnection.id !== message.connection.id){
-              thisConnection.sendMessage(messagePayload, 'say');
+          if(thisConnection.rooms.indexOf(messagePayload.room) > -1){
+            if(message.connection === undefined || thisConnection.id !== messagePayload.from){
+              api.chatRoom.handleCallbacks(thisConnection, messagePayload.room, 'say', messagePayload, function(err, newMessagePaylaod){
+                if(!err){ thisConnection.sendMessage(newMessagePaylaod, 'say'); }
+              });
             }
           }
         }
@@ -91,11 +100,9 @@ module.exports = {
                 api.chatRoom.removeMember(id, room);
               }
 
-              api.chatRoom.setAuthenticationPattern(room, null, null, function(){
-                api.redis.client.srem(api.chatRoom.keys.rooms, room, function(){
-                  api.redis.client.del(api.chatRoom.keys.members + room, function(){
-                    if(typeof callback === 'function'){ callback() }
-                  });
+              api.redis.client.srem(api.chatRoom.keys.rooms, room, function(){
+                api.redis.client.del(api.chatRoom.keys.members + room, function(){
+                  if(typeof callback === 'function'){ callback() }
                 });
               });
               
@@ -114,42 +121,6 @@ module.exports = {
           found = true;
         }
         if(typeof callback === 'function'){ callback(err, found) }
-      });
-    }
-    
-    api.chatRoom.setAuthenticationPattern = function(room, key, value, callback){
-      api.chatRoom.exists(room, function(err, found){
-        if(found === true){
-          if(key === null || key === undefined){
-            api.redis.client.hdel(api.chatRoom.keys.auth, room, function(err){
-              if(typeof callback === 'function'){ callback(err) }
-            });
-          } else {
-            var data = {}
-            data[key] = value;
-            api.redis.client.hset(api.chatRoom.keys.auth, room, JSON.stringify(data), function(){
-              api.redis.client.hgetall((api.chatRoom.keys.members + room), function(err, members){
-                if(api.utils.hashLength( members ) === 0){
-                  if(typeof callback === 'function'){ callback(err); }
-                }else{
-                  if(!err && members){
-                    var authenticators = [];
-                    for(var member in members){
-                      authenticators.push(async.apply(api.chatRoom.reAuthenticate, member));
-                    }
-                    async.parallel(authenticators, function(err){
-                      if(typeof callback === 'function'){ callback(); }
-                    })
-                  }else{
-                    if(typeof callback === 'function'){ callback(err); }
-                  }
-                }
-              });        
-            });
-          }
-        } else {
-          if(typeof callback === 'function'){ callback( api.config.errors.connectionRoomNotExist(room), null) }
-        }
       });
     }
     
@@ -185,71 +156,13 @@ module.exports = {
         if(typeof callback === 'function'){ callback( api.config.errors.connectionRoomRequired() , null); }
       }
     }
-
-    api.chatRoom.authorize = function(connection, room, callback){
-      api.chatRoom.exists(room, function(err, found){
-        if(found === true){
-          api.redis.client.hget(api.chatRoom.keys.auth, room, function(err, rawAuth){
-            var auth = {};
-            if(rawAuth !== undefined && rawAuth !== null){ auth = JSON.parse(rawAuth) }
-            var authorized = true;
-            for(var k in auth){
-              if(connection[k] === null || connection[k] === undefined || connection[k] !== auth[k]){
-                authorized = false;
-              }
-            }
-            callback(err, authorized);
-          });
-        } else {
-          if(typeof callback === 'function'){ callback( api.config.errors.connectionRoomNotExist(room), null) }
-        }
-      });
-    }
-
-    api.chatRoom.reAuthenticate = function(connectionId, callback){
-      if(api.connections.connections[connectionId]){
-        var connection = api.connections.connections[connectionId];
-        if(connection.rooms.length === 0){
-          if(typeof callback === 'function'){ callback([]); }
-        }else{
-          var started   = 0;
-          var failed    = [];
-          var succeeded = [];
-          connection.rooms.forEach(function(room){
-            started++;
-            (function(room){
-              api.chatRoom.authorize(connection, room, function(err, authorized){
-                started--;
-                if(authorized === true) { succeeded.push(room); }
-                if(authorized === false){ failed.push(room); }
-                if(started === 0){
-                  if(failed.length === 0){
-                    if(typeof callback === 'function'){ callback(err, failed); }
-                  }else{
-                    failed.forEach(function(room){
-                      started++;
-                      api.chatRoom.removeMember(connectionId, room, function(){
-                        started--;
-                        if(started === 0){
-                          if(typeof callback === 'function'){ callback(err, failed); }
-                        }
-                      });
-                    });
-                  }
-                }
-              });
-            })(room)
-          });
-        }
-      }else{
-        api.redis.doCluster('api.chatRoom.reAuthenticate', [connectionId], connectionId, callback);
-      }
-    }
     
     api.chatRoom.generateMemberDetails = function(connection){
-    	return { id: connection.id,
-    	         joinedAt: new Date().getTime(),
-    	         host: api.id };
+    	return { 
+        id: connection.id,
+        joinedAt: new Date().getTime(),
+        host: api.id 
+       };
     }
 
     api.chatRoom.addMember = function(connectionId, room, callback){
@@ -258,23 +171,16 @@ module.exports = {
         if(connection.rooms.indexOf(room) < 0){
           api.chatRoom.exists(room, function(err, found){
             if(found === true){
-              api.chatRoom.authorize(connection, room, function(err, authorized){
-                if(authorized === true){
-                  api.redis.client.hget(api.chatRoom.keys.members + room, connection.id, function(err, memberDetails){
-                    if(memberDetails === null || memberDetails === undefined){
-                      memberDetails = api.chatRoom.generateMemberDetails( connection );
-                      api.redis.client.hset(api.chatRoom.keys.members + room, connection.id, JSON.stringify(memberDetails), function(){
-                        connection.rooms.push(room);
-                        api.stats.increment('chatRoom:roomMembers:' + room);
-                        api.chatRoom.handleCallbacks(connection, room, true);
-                        if(typeof callback === 'function'){ callback(null, true); }
-                      });
-                    } else {
-                      if(typeof callback === 'function'){ callback( api.config.errors.connectionAlreadyInRoom(room), false) }
-                    }
+              api.chatRoom.handleCallbacks(connection, room, 'join', null, function(err){
+                if(err){
+                  callback(err, false);
+                }else{
+                  var memberDetails = api.chatRoom.generateMemberDetails( connection );
+                  api.redis.client.hset(api.chatRoom.keys.members + room, connection.id, JSON.stringify(memberDetails), function(){
+                    connection.rooms.push(room);
+                    api.stats.increment('chatRoom:roomMembers:' + room);
+                    if(typeof callback === 'function'){ callback(null, true); }
                   });
-                } else {
-                  if(typeof callback === 'function'){ callback( api.config.errors.connectionNotAuthorized(room), false) }
                 }
               });
             } else {
@@ -295,12 +201,17 @@ module.exports = {
         if(connection.rooms.indexOf(room) > -1){
           api.chatRoom.exists(room, function(err, found){
             if(found){
-              api.stats.increment('chatRoom:roomMembers:' + room, -1);
-              api.redis.client.hdel(api.chatRoom.keys.members + room, connection.id, function(){
-                api.chatRoom.handleCallbacks(connection, room, false);
-                var index = connection.rooms.indexOf(room);
-                if(index > -1){ connection.rooms.splice(index, 1); }
-                if(typeof callback === 'function'){ callback(null, true) }
+              api.chatRoom.handleCallbacks(connection, room, 'leave', null, function(err){
+                if(err){
+                  callback(err, false);
+                }else{
+                  api.stats.increment('chatRoom:roomMembers:' + room, -1);
+                  api.redis.client.hdel(api.chatRoom.keys.members + room, connection.id, function(){
+                    var index = connection.rooms.indexOf(room);
+                    if(index > -1){ connection.rooms.splice(index, 1); }
+                    if(typeof callback === 'function'){ callback(null, true) }
+                  });
+                }
               });
             }else{
               if(typeof callback === 'function'){ callback( api.config.errors.connectionRoomNotExist(room), false) }
@@ -314,20 +225,45 @@ module.exports = {
       }
     }
 
-    api.chatRoom.handleCallbacks = function(connection, room, direction){
+    api.chatRoom.handleCallbacks = function(connection, room, direction, messagePayload, next){
+      //callbacks should be of the form f(callback, )
+
       var collecton;
-      if(direction === true){
+      var orderedCallbacks = [];
+      if(direction === 'join'){
         collecton = api.chatRoom.joinCallbacks;
-      } else {
+      } else if(direction === 'leave' ) {
         collecton = api.chatRoom.leaveCallbacks;
+      } else if(direction === 'say' ) {
+        collecton = api.chatRoom.sayCallbacks;
       }
       
       var priorities = [];
-      for(var c in collecton) priorities.push(c);
+      for(var c in collecton){ priorities.push(c); }
       priorities.forEach(function(priority){
         collecton[priority].forEach(function(c){
-          c(connection, room);   
+          if(messagePayload){
+            orderedCallbacks.push( function(callback){
+              c(connection, room, messagePayload, callback);
+            }); 
+          }else{
+            orderedCallbacks.push( function(callback){
+              c(connection, room, callback);
+            });
+          }
         });
+      });
+
+      async.series(orderedCallbacks, function(err, data){
+        var newMessagePaylaod = messagePayload;
+        while(data.length > 0){
+          var thisData = data.pop();
+          if(thisData){ 
+            newMessagePaylaod = thisData; 
+            break;
+          }
+        }
+        next(err, newMessagePaylaod)
       });
     }
 
@@ -344,14 +280,7 @@ module.exports = {
     if(api.config.general.startingChatRooms){
       for(var room in api.config.general.startingChatRooms){
         api.log('ensuring the existence of the chatRoom: ' + room);
-        api.chatRoom.add(room, function(){
-          if(api.config.general.startingChatRooms[room]){
-            for(var authKey in api.config.general.startingChatRooms[room]){
-              var authValue = api.config.general.startingChatRooms[room][authKey];
-              api.chatRoom.setAuthenticationPattern(room, authKey, authValue);
-            }
-          }
-        });
+        api.chatRoom.add(room);
       }
     }
 

--- a/test/core/actionCluster.js
+++ b/test/core/actionCluster.js
@@ -481,16 +481,16 @@ describe('Core: Action Cluster', function(){
           });
         });
 
-        it('can add middleware in a particular order', function(done){
+        it('can add middleware in a particular order and will be passed modified messagePayloads', function(done){
           apiA.chatRoom.addSayCallback(function(connection, room, messagePayload, callback){
             messagePayload.message = 'MIDDLEWARE 1';
             callback(null, messagePayload);
-          }, 2000);
+          }, 1000);
 
           apiA.chatRoom.addSayCallback(function(connection, room, messagePayload, callback){
-            messagePayload.message = 'MIDDLEWARE 2';
+            messagePayload.message = messagePayload.message + ' MIDDLEWARE 2';
             callback(null, messagePayload);
-          }, 1000);
+          }, 2000);
 
           clientA.verbs('roomAdd','defaultRoom', function(err, data){
           clientB.verbs('roomAdd','defaultRoom', function(err, data){
@@ -498,7 +498,7 @@ describe('Core: Action Cluster', function(){
 
             setTimeout(function(){
               var lastMessage = clientA.messages[(clientA.messages.length - 1)]
-              lastMessage.message.should.equal('MIDDLEWARE 1');
+              lastMessage.message.should.equal('MIDDLEWARE 1 MIDDLEWARE 2');
 
               done();
             }, 100);

--- a/test/core/actionCluster.js
+++ b/test/core/actionCluster.js
@@ -334,34 +334,6 @@ describe('Core: Action Cluster', function(){
         });
       });
 
-      // it('can add authorized members to secure rooms', function(done){
-      //   var client = new apiA.specHelper.connection();
-      //   apiA.chatRoom.add('newRoom', function(err){
-      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-      //       client.auth = true;
-      //       apiA.chatRoom.addMember(client.id, 'newRoom', function(err, didAdd){
-      //         didAdd.should.equal(true);
-      //         client.destroy();
-      //         done();
-      //       });
-      //     });
-      //   });
-      // });
-
-      // it('will not add a member with bad auth to a secure room', function(done){
-      //   var client = new apiA.specHelper.connection();
-      //   apiA.chatRoom.add('newRoom', function(err){
-      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-      //       client.auth = false;
-      //       apiA.chatRoom.addMember(client.id, 'newRoom', function(err, didAdd){
-      //         didAdd.should.equal(false);
-      //         client.destroy();
-      //         done();
-      //       });
-      //     });
-      //   });
-      // })
-
       it('server will not remove a member not in a room', function(done){
         var client = new apiA.specHelper.connection();
         apiA.chatRoom.removeMember(client.id, 'defaultRoom', function(err, didRemove){
@@ -425,62 +397,6 @@ describe('Core: Action Cluster', function(){
           });            
         });
       })
-
-      // it('can authorize clients against rooms PASSING', function(done){
-      //   var client = new apiA.specHelper.connection();
-      //   client.auth = true;
-      //   apiA.chatRoom.add('newRoom', function(err){
-      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-      //       apiA.chatRoom.authorize(client, 'newRoom', function(err, authed){
-      //         should.not.exist(err);
-      //         authed.should.equal(true);
-      //         client.destroy();
-      //         done();
-      //       });
-      //     });
-      //   });
-      // });
-
-      // it('can authorize clients against rooms FAILING', function(done){
-      //   var client = new apiA.specHelper.connection();
-      //   client.auth = false;
-      //   apiA.chatRoom.add('newRoom', function(err){
-      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-      //       apiA.chatRoom.authorize(client, 'newRoom', function(err, authed){
-      //         should.not.exist(err);
-      //         authed.should.equal(false);
-      //         client.destroy();
-      //         done();
-      //       });
-      //     });
-      //   });
-      // });
-
-      // it('server change auth for a room and all connections will be checked', function(done){
-      //   var clientA = new apiA.specHelper.connection();
-      //   var clientB = new apiA.specHelper.connection();
-      //   clientA.auth = true;
-      //   clientA._name = 'a';
-      //   clientB.auth = false;
-      //   clientB._name = 'b';
-      //   apiA.chatRoom.add('newRoom', function(err){
-      //     apiA.chatRoom.addMember(clientA.id, 'newRoom', function(err, didAdd){
-      //       apiA.chatRoom.addMember(clientB.id, 'newRoom', function(err, didAdd){
-      //         clientA.rooms[0].should.equal('newRoom');
-      //         clientB.rooms[0].should.equal('newRoom');
-      //         apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-      //           should.not.exist(err);
-      //           clientA.rooms[0].should.equal('newRoom');
-      //           clientA.rooms.length.should.equal(1);
-      //           clientB.rooms.length.should.equal(0);
-      //           clientA.destroy();
-      //           clientB.destroy();
-      //           done();
-      //         });
-      //       });
-      //     });
-      //   });
-      // });
 
       describe('chat middleware', function(){
 

--- a/test/core/actionCluster.js
+++ b/test/core/actionCluster.js
@@ -334,33 +334,33 @@ describe('Core: Action Cluster', function(){
         });
       });
 
-      it('can add authorized members to secure rooms', function(done){
-        var client = new apiA.specHelper.connection();
-        apiA.chatRoom.add('newRoom', function(err){
-          apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-            client.auth = true;
-            apiA.chatRoom.addMember(client.id, 'newRoom', function(err, didAdd){
-              didAdd.should.equal(true);
-              client.destroy();
-              done();
-            });
-          });
-        });
-      });
+      // it('can add authorized members to secure rooms', function(done){
+      //   var client = new apiA.specHelper.connection();
+      //   apiA.chatRoom.add('newRoom', function(err){
+      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
+      //       client.auth = true;
+      //       apiA.chatRoom.addMember(client.id, 'newRoom', function(err, didAdd){
+      //         didAdd.should.equal(true);
+      //         client.destroy();
+      //         done();
+      //       });
+      //     });
+      //   });
+      // });
 
-      it('will not add a member with bad auth to a secure room', function(done){
-        var client = new apiA.specHelper.connection();
-        apiA.chatRoom.add('newRoom', function(err){
-          apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-            client.auth = false;
-            apiA.chatRoom.addMember(client.id, 'newRoom', function(err, didAdd){
-              didAdd.should.equal(false);
-              client.destroy();
-              done();
-            });
-          });
-        });
-      })
+      // it('will not add a member with bad auth to a secure room', function(done){
+      //   var client = new apiA.specHelper.connection();
+      //   apiA.chatRoom.add('newRoom', function(err){
+      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
+      //       client.auth = false;
+      //       apiA.chatRoom.addMember(client.id, 'newRoom', function(err, didAdd){
+      //         didAdd.should.equal(false);
+      //         client.destroy();
+      //         done();
+      //       });
+      //     });
+      //   });
+      // })
 
       it('server will not remove a member not in a room', function(done){
         var client = new apiA.specHelper.connection();
@@ -426,60 +426,228 @@ describe('Core: Action Cluster', function(){
         });
       })
 
-      it('can authorize clients against rooms PASSING', function(done){
-        var client = new apiA.specHelper.connection();
-        client.auth = true;
-        apiA.chatRoom.add('newRoom', function(err){
-          apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-            apiA.chatRoom.authorize(client, 'newRoom', function(err, authed){
-              should.not.exist(err);
-              authed.should.equal(true);
-              client.destroy();
-              done();
+      // it('can authorize clients against rooms PASSING', function(done){
+      //   var client = new apiA.specHelper.connection();
+      //   client.auth = true;
+      //   apiA.chatRoom.add('newRoom', function(err){
+      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
+      //       apiA.chatRoom.authorize(client, 'newRoom', function(err, authed){
+      //         should.not.exist(err);
+      //         authed.should.equal(true);
+      //         client.destroy();
+      //         done();
+      //       });
+      //     });
+      //   });
+      // });
+
+      // it('can authorize clients against rooms FAILING', function(done){
+      //   var client = new apiA.specHelper.connection();
+      //   client.auth = false;
+      //   apiA.chatRoom.add('newRoom', function(err){
+      //     apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
+      //       apiA.chatRoom.authorize(client, 'newRoom', function(err, authed){
+      //         should.not.exist(err);
+      //         authed.should.equal(false);
+      //         client.destroy();
+      //         done();
+      //       });
+      //     });
+      //   });
+      // });
+
+      // it('server change auth for a room and all connections will be checked', function(done){
+      //   var clientA = new apiA.specHelper.connection();
+      //   var clientB = new apiA.specHelper.connection();
+      //   clientA.auth = true;
+      //   clientA._name = 'a';
+      //   clientB.auth = false;
+      //   clientB._name = 'b';
+      //   apiA.chatRoom.add('newRoom', function(err){
+      //     apiA.chatRoom.addMember(clientA.id, 'newRoom', function(err, didAdd){
+      //       apiA.chatRoom.addMember(clientB.id, 'newRoom', function(err, didAdd){
+      //         clientA.rooms[0].should.equal('newRoom');
+      //         clientB.rooms[0].should.equal('newRoom');
+      //         apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
+      //           should.not.exist(err);
+      //           clientA.rooms[0].should.equal('newRoom');
+      //           clientA.rooms.length.should.equal(1);
+      //           clientB.rooms.length.should.equal(0);
+      //           clientA.destroy();
+      //           clientB.destroy();
+      //           done();
+      //         });
+      //       });
+      //     });
+      //   });
+      // });
+
+      describe('chat middleware', function(){
+
+        var clientA, clientB;
+
+        beforeEach(function(done){
+          clientA = new apiA.specHelper.connection();
+          clientB = new apiA.specHelper.connection();
+
+          done()
+        });
+
+        afterEach(function(done){
+          apiA.chatRoom.joinCallbacks  = {};
+          apiA.chatRoom.leaveCallbacks = {};
+          apiA.chatRoom.sayCallbacks   = {};
+
+          clientA.destroy();
+          clientB.destroy();
+          setTimeout(function(){
+            done();
+          }, 100);
+        });
+
+        it('(join + leave) can add middleware to announce members', function(done){
+          apiA.chatRoom.addJoinCallback(function(connection, room, callback){
+            apiA.chatRoom.broadcast({}, room, 'I have entered the room: ' + connection.id, function(e){
+              callback();
             });
           });
-        });
-      });
 
-      it('can authorize clients against rooms FAILING', function(done){
-        var client = new apiA.specHelper.connection();
-        client.auth = false;
-        apiA.chatRoom.add('newRoom', function(err){
-          apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
-            apiA.chatRoom.authorize(client, 'newRoom', function(err, authed){
-              should.not.exist(err);
-              authed.should.equal(false);
-              client.destroy();
-              done();
+          apiA.chatRoom.addLeaveCallback(function(connection, room, callback){
+            apiA.chatRoom.broadcast({}, room, 'I have left the room: ' + connection.id, function(e){
+              callback();
             });
           });
-        });
-      });
 
-      it('server change auth for a room and all connections will be checked', function(done){
-        var clientA = new apiA.specHelper.connection();
-        var clientB = new apiA.specHelper.connection();
-        clientA.auth = true;
-        clientA._name = 'a';
-        clientB.auth = false;
-        clientB._name = 'b';
-        apiA.chatRoom.add('newRoom', function(err){
-          apiA.chatRoom.addMember(clientA.id, 'newRoom', function(err, didAdd){
-            apiA.chatRoom.addMember(clientB.id, 'newRoom', function(err, didAdd){
-              clientA.rooms[0].should.equal('newRoom');
-              clientB.rooms[0].should.equal('newRoom');
-              apiA.chatRoom.setAuthenticationPattern('newRoom', 'auth', true, function(err){
+          clientA.verbs('roomAdd','defaultRoom', function(err, data){
+            should.not.exist(err);
+            clientB.verbs('roomAdd','defaultRoom', function(err, data){
+              should.not.exist(err);
+              clientB.verbs('roomLeave','defaultRoom', function(err, data){
                 should.not.exist(err);
-                clientA.rooms[0].should.equal('newRoom');
-                clientA.rooms.length.should.equal(1);
-                clientB.rooms.length.should.equal(0);
-                clientA.destroy();
-                clientB.destroy();
-                done();
+
+                setTimeout(function(){
+                  clientA.messages[1].message.should.equal('I have entered the room: ' + clientA.id)
+                  clientA.messages[2].message.should.equal('I have entered the room: ' + clientB.id)
+                  clientA.messages[3].message.should.equal('I have left the room: ' + clientB.id)
+
+                  done();
+                }, 100);
+
               });
             });
           });
         });
+
+        it('(say) can modify message payloads', function(done){
+          apiA.chatRoom.addSayCallback(function(connection, room, messagePayload, callback){
+            if(messagePayload.from !== 0){
+              messagePayload.message = 'something else';
+            }
+            callback(null, messagePayload);
+          });
+
+          clientA.verbs('roomAdd','defaultRoom', function(err, data){
+            should.not.exist(err);
+          clientB.verbs('roomAdd','defaultRoom', function(err, data){
+            should.not.exist(err);
+          clientB.verbs('say', ['defaultRoom', 'something', 'awesome'], function(err, data){
+            should.not.exist(err);
+
+            setTimeout(function(){
+              var lastMessage = clientA.messages[(clientA.messages.length - 1)]
+              lastMessage.message.should.equal('something else');
+
+              done();
+            }, 100);
+
+          });
+          });
+          });
+        });
+
+        it('can add middleware in a particular order', function(done){
+          apiA.chatRoom.addSayCallback(function(connection, room, messagePayload, callback){
+            messagePayload.message = 'MIDDLEWARE 1';
+            callback(null, messagePayload);
+          }, 2000);
+
+          apiA.chatRoom.addSayCallback(function(connection, room, messagePayload, callback){
+            messagePayload.message = 'MIDDLEWARE 2';
+            callback(null, messagePayload);
+          }, 1000);
+
+          clientA.verbs('roomAdd','defaultRoom', function(err, data){
+          clientB.verbs('roomAdd','defaultRoom', function(err, data){
+          clientB.verbs('say', ['defaultRoom', 'something', 'awesome'], function(err, data){
+
+            setTimeout(function(){
+              var lastMessage = clientA.messages[(clientA.messages.length - 1)]
+              lastMessage.message.should.equal('MIDDLEWARE 1');
+
+              done();
+            }, 100);
+
+          });
+          });
+          });
+        });
+
+        it('say middleware can block excecution', function(done){
+          apiA.chatRoom.addSayCallback(function(connection, room, messagePayload, callback){
+            callback(new Error('messages blocked'));
+          });
+
+          clientA.verbs('roomAdd','defaultRoom', function(err, data){
+          clientB.verbs('roomAdd','defaultRoom', function(err, data){
+          clientB.verbs('say', ['defaultRoom', 'something', 'awesome'], function(err, data){
+
+            setTimeout(function(){
+              // welcome message is passed, no join/leave/or say messages
+              clientA.messages.length.should.equal(1);
+
+              done();
+            }, 100);
+
+          });
+          });
+          });
+        });
+
+        it('join middleware can block excecution', function(done){
+          apiA.chatRoom.addJoinCallback(function(connection, room, callback){
+            callback(new Error('joining rooms blocked'));
+          });
+
+          clientA.verbs('roomAdd','defaultRoom', function(error, didJoin){
+            String(error).should.equal('Error: joining rooms blocked');
+            didJoin.should.equal(false);
+            clientA.rooms.length.should.equal(0);
+
+            done();
+          });
+        });
+
+        it('leave middleware can block excecution', function(done){
+          apiA.chatRoom.addLeaveCallback(function(connection, room, callback){
+            callback(new Error('Hotel California'));
+          });
+
+          clientA.verbs('roomAdd','defaultRoom', function(error, didJoin){
+            should.not.exist(error);
+            didJoin.should.equal(true);
+            clientA.rooms.length.should.equal(1);
+            clientA.rooms[0].should.equal('defaultRoom');
+
+            clientA.verbs('roomLeave','defaultRoom', function(error, didLeave){
+              String(error).should.equal('Error: Hotel California');
+              didLeave.should.equal(false);
+              clientA.rooms.length.should.equal(1);
+
+              done();
+            });
+          });
+        });
+
       });
 
     });


### PR DESCRIPTION
## Chat

This PR updates the chat sub-system in some major ways:

- Added a new type of chat middleware, `sayCallbacks`.  This allows you to modify messages being sent to clients, log all messages your self, etc.  It is similar in nature to the `joinCallbacks` and  `leaveCallbacks`.

- All chat callbacks now process serially.  

- All chat callbacks now require a callback as the final argument:

```javascript
var chatMiddlewareToAnnounceNewMembers = function(connection, room, callback){
  api.chatRoom.broadcast({}, room, 'I have entered the room: ' + connection.id, function(e){
      callback();
  });
}

api.chatRoom.addJoinCallback(chatMiddlewareToAnnounceNewMembers, 100);

var chatMiddlewareToAnnounceGoneMembers = function(connection, room, callback){
  api.chatRoom.broadcast({}, room, 'I have left the room: ' + connection.id, function(e){
      callback();
  });
}

api.chatRoom.addLeaveCallback(chatMiddlewareToAnnounceGoneMembers, 100);

var middlewareToAddSimleyFacesToAllMessages = function(connection, room, messagePayload, callback){
  messagePayload.message = messagePayload.message + ' :)';
  callback(null, messagePayload);
}

api.chatRoom.addSayCallback(middlewareToAddSimleyFacesToAllMessages, 100);
```
- In the example above, I want to announce the member joining the room, but he has not yet been added to the room, as the callback chain is still firing.  If the connection itself were to make the broadcast, it would fail because the connection is not in the room.  Instead, an empty `{}` connection is used to proxy the message coming from the 'system'

- Only the `sayCallbacks` have a second return value on the callback, `messagePayload`.  This allows you to modify the message being sent to your clients. 

-`messagePayload` will be modified and and passed on to all `addSayCallback` middlewares inline, so you can append and modify it as you go

- If you have a number of callbacks (`sayCallbacks`, `joinCallbacks` or  `leaveCallbacks`), the priority maters, and you can block subsequent methods from firing by returning an error to the callback.  

```javascript
// in this example no one will be able to join any room, and the broadcast callback will never be invoked.
api.chatRoom.addJoinCallback(function(connection, room, callback){
  callback(new Error('blocked from joining the room'));
}, 100);

api.chatRoom.addJoinCallback(function(connection, room, callback){
  api.chatRoom.broadcast({}, room, 'I have entered the room: ' + connection.id, function(e){
    callback();
  });
}, 200);
```

-  If a `sayCallback` is blocked/errored, the message will simply not be delivered to the client.  If a  `joinCallbacks` or  `leaveCallbacks` is blocked/errored, the verb or method used to invoke the call will be returned that error.

- Because chat middleware can be used to control room access, the previous authentication system has been removed.  This new system allows for far greater flexibility in your chat room access rules, including async behavior, such as defering to a database.  You no longer need to pre-load authentication values onto the connections at boot.  The following methods are removed:
  - api.chatRoom.setAuthenticationPattern(room, key, value, callback)
  - api.chatRoom.authorize(connection, room, callback)
  - api.chatRoom.reAuthenticate(connectionId, callback)

## Misc

- Websocket client will now always check server for listing of rooms that the client is a member of with both `roomAdd` and `roomLeave`.  This is required now that these methods can fail async.