### PR TITLE
Allow the use of multiple config specifications.

### DIFF
--- a/initializers/configLoader.js
+++ b/initializers/configLoader.js
@@ -46,19 +46,16 @@ module.exports = {
       api.env = process.env.NODE_ENV;
     }
 
-    // We now support multiple configuration paths. Repeated uses of --config will add paths to examine. But note that
-    // the old behavior <10.x was that specifying --config would OVERRIDE the default path (the configs that ship with
-    // AH). To preserve that behavior, we use the AH default here as before, but overwrite below if config is specified.
+    // We support multiple configuration paths as follows:
     //
-    // Load order:
-    // 1. Project 'config' folder, if exists
-    // 2. "actionhero --config=PATH"
-    // 3. "ACTIONHERO_CONFIG=PATH npm start"
+    // 1. Use the project 'config' folder, if it exists.
+    // 2. "actionhero --config=PATH1 --config=PATH2 --config=PATH3,PATH4"
+    // 3. "ACTIONHERO_CONFIG=PATH1,PATH2 npm start"
     //
-    // NOTE: The original behavior was to REPLACE the default 'config' folder if either --config or ACTIONHERO_CONFIG
-    // were specified. This means if you want to use 'config' and 'local-config' together, for example, you need to
-    // re-specify both (e.g. "--config=config --config=local-config" or "--config=config,local-config".) If you just
-    // specify "--config=local-config", the default 'config' folder will be ignored.
+    // Note that if --config or ACTIONHERO_CONFIG are used, they _overwrite_ the use of the default "config" folder. If
+    // you wish to use both, you need to re-specify "config", e.g. "--config=config,local-config". Also, note that
+    // specifying multiple --config options on the command line does exactly the same thing as using one parameter with
+    // comma separators, however the environment variable method only supports the comma-delimited syntax.
     var configPaths = [];
 
     function addConfigPath(pathToCheck, alreadySplit) {

--- a/initializers/configLoader.js
+++ b/initializers/configLoader.js
@@ -54,6 +54,11 @@ module.exports = {
     // 1. Project 'config' folder, if exists
     // 2. "actionhero --config=PATH"
     // 3. "ACTIONHERO_CONFIG=PATH npm start"
+    //
+    // NOTE: The original behavior was to REPLACE the default 'config' folder if either --config or ACTIONHERO_CONFIG
+    // were specified. This means if you want to use 'config' and 'local-config' together, for example, you need to
+    // re-specify both (e.g. "--config=config --config=local-config" or "--config=config,local-config".) If you just
+    // specify "--config=local-config", the default 'config' folder will be ignored.
     var configPaths = [];
 
     function addConfigPath(pathToCheck, alreadySplit) {
@@ -74,9 +79,12 @@ module.exports = {
       }
     }
 
-    ['config', argv.config, process.env.ACTIONHERO_CONFIG].map(function(entry) {
+    [argv.config, process.env.ACTIONHERO_CONFIG].map(function(entry) {
       addConfigPath(entry, false);
     });
+    if (configPaths.length < 1) {
+      addConfigPath('config', false);
+    }
     if (configPaths.length < 1) {
       throw new Error(configPaths + 'No config directory found in this project, specified with --config, or found in process.env.ACTIONHERO_CONFIG');
     }


### PR DESCRIPTION
This PR allows the use of multiple config paths. A typical use-case would be to provide default config settings in a project, with "local" settings that apply only to a specific server. This makes it easy to keep database passwords, API keys, and other security-sensitive information out of your repository, or to adjust server-specific settings such as which nodes will run background tasks vs. Web services.

This change preserves the existing load order for ActionHero configs:

1. The project's 'config' folder, if exists
1. `actionhero --config=PATH` parameters. More than one --config value may now be provided.
1. `ACTIONHERO_CONFIG=PATH npm start` style environment variables.

In addition, config paths may include more than one path, separated by commas. This is handy when using the environment-variable style, e.g. `ACTIONHERO_CONFIG=config,local-config npm start`.

As with standard ActionHero configs, override files do not need to re-specify every key from the default file - just the keys being overridden.
