### PR TITLE
Added new directory command to Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently actionhero supports:
 
 ## Quick Start
 
+- `mkdir new_project; cd new_project`
 - `npm install actionhero`
 - `./node_modules/.bin/actionhero generate`
 - `npm start`


### PR DESCRIPTION
Running the existing instructions without knowing how the generator works resulted in a mess of new files + directories in my home dir. No big deal, but it is a noob pitfall that could be easily avoided, so I thought I would mention it here.

Another solution would be to add the ability to specify a target directory to the generator tool, e.g. `actionhero generate my_new_project` that would create the `my_new_project` directory if it didn't already exist.