### PR TITLE
Fix unexpected param filtering behavior - resolves #582

### DIFF
--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -176,7 +176,7 @@ module.exports = {
       if(api.config.general.disableParamScrubbing !== true){
         for(var p in self.connection.params){
           if(
-              api.params.postVariables.indexOf(p) < 0 &&
+              api.params.globalSafeParams.indexOf(p) < 0 &&
               self.actionTemplate.inputs &&
               Object.keys(self.actionTemplate.inputs).indexOf(p) < 0
           ){

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -308,6 +308,13 @@ describe('Core: API', function(){
       });
     });
 
+    it('will filter params not set in the target action or global safelist', function(done){
+      api.specHelper.runAction('testAction', {requiredParam: true, sleepDuration: true }, function(response){
+        should.not.exist(response.requesterInformation.receivedParams.sleepDuration);
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
Modify the reduceParams function of the actionProcessor initializer to allow params from the globalSafeParams array rather than the postVariables array