### PR TITLE
Formal EventEmitter inheritance for AH client

### DIFF
--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -19,7 +19,9 @@ var ActionheroClient = function(options, client){
 }
 
 if(typeof Primus === 'undefined'){
-  ActionheroClient.prototype = new EventEmitter();
+  var util = require('util');
+  var EventEmitter = require('events').EventEmitter;
+  util.inherits(ActionheroClient, EventEmitter);
 }else{
   ActionheroClient.prototype = new Primus.EventEmitter();
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "mocha": "~2.x",
-    "should": "~4.x",
+    "should": "~5.x",
     "request": "~2.53.x",
     "redis-sentinel-client": "latest",
     "blanket": "^1.1.6",


### PR DESCRIPTION
iojs v1.3.0 exposed a bug where (in testing) the AH websocket client lib could have errors with multiple clients.  We were not 'formally' declaring the client as extension of the EventEmmiter, rather just hijacking the prototype. 