### PR TITLE
Pass through task documentation

### DIFF
--- a/docs/core/tasks.md
+++ b/docs/core/tasks.md
@@ -125,8 +125,7 @@ var task = {
   frequency:     0,
   run: function(api, params, next){
     api.sendEmail(params.email, function(err){
-      if(err != null){ api.log(err, 'error'); }
-      next();
+      next(err); //task will fail if sendEmail does
     })
   }
 };


### PR DESCRIPTION
Added documentation for a tasks `next` callback.
Fix `api.tasks.allWorkingOn` docs.
Make examples consistent by removing parameters to `next` callback.