### PR TITLE
initializers to return errors which will be passed up to the boot process

### DIFF
--- a/actionhero.js
+++ b/actionhero.js
@@ -275,13 +275,13 @@ actionhero.prototype.restart = function(callback){
 
 var fatalError = function(api, errors, type){
   if(errors && !(errors instanceof Array)){ errors = [errors]; }
-  errors.forEach(function(){
+  if(errors){ 
     api.log('Error with initilizer step: ' + type, 'emerg');
     errors.forEach(function(err){
       api.log(err.stack, 'emerg');
     });
-  });
-  if(errors){ process.exit(1); }
+    process.exit(1); 
+  }
 }
 
 var sortNumber = function(a,b) {

--- a/actionhero.js
+++ b/actionhero.js
@@ -177,10 +177,10 @@ actionhero.prototype.initialize = function(params, callback){
       });
     } );
 
-    async.series(self.loadInitializers);
+    async.series(self.loadInitializers, function(errors){ fatalError(self.api, errors, 'initialize'); });
   } );
 
-  async.series(self.configInitializers);
+  async.series(self.configInitializers, function(errors){ fatalError(self.api, errors, 'config'); });
 };
 
 actionhero.prototype.start = function(params, callback){
@@ -203,7 +203,7 @@ actionhero.prototype.start = function(params, callback){
       callback(null, self.api);
     });
 
-    async.series(self.startInitializers);
+    async.series(self.startInitializers, function(errors){ fatalError(self.api, errors, 'start'); });
   }
 
   if(self.api.initialized === true){
@@ -240,7 +240,7 @@ actionhero.prototype.stop = function(callback){
       });
     });
 
-    async.series(self.stopInitializers);
+    async.series(self.stopInitializers, function(errors){ fatalError(self.api, errors, 'stop'); });
 
   } else if(self.api.shuttingDown === true){
     // double sigterm; ignore it
@@ -272,6 +272,17 @@ actionhero.prototype.restart = function(callback){
 };
 
 //
+
+var fatalError = function(api, errors, type){
+  if(errors && !(errors instanceof Array)){ errors = [errors]; }
+  errors.forEach(function(){
+    api.log('Error with initilizer step: ' + type, 'emerg');
+    errors.forEach(function(err){
+      api.log(err.stack, 'emerg');
+    });
+  });
+  if(errors){ process.exit(1); }
+}
 
 var sortNumber = function(a,b) {
     return a - b;

--- a/bin/methods/start.js
+++ b/bin/methods/start.js
@@ -16,9 +16,8 @@ exports.start = function(binary, next){
     if(cluster.isWorker){ process.send(state); }
     actionhero.start(function(err, apiFromCallback){
       if(err){
-        if(cluster.isWorker){ process.send('failed_to_boot'); }
         binary.log(err);
-        process.exit();
+        process.exit(1);
       } else {
         state = 'started';
         if(cluster.isWorker){ process.send(state); }
@@ -53,7 +52,9 @@ exports.start = function(binary, next){
   }
 
   var stopProcess = function(){
-    setTimeout(process.exit, shutdownTimeout)
+    setTimeout(function(){
+      process.exit(1);
+    }, shutdownTimeout)
     // finalTimer.unref();
     stopServer(function(){
       process.nextTick(function(){

--- a/config/logger.js
+++ b/config/logger.js
@@ -21,7 +21,9 @@ exports.default = {
     try{
       fs.mkdirSync('./log');
     } catch(e) {
-      if(e.code !== 'EEXIST'){ console.log(e); process.exit(); }
+      if(e.code !== 'EEXIST'){
+        return next([new Error('Cannot create ./log directory'), e])
+      }
     }
     logger.transports.push(function(api, winston) {
       return new (winston.transports.File)({

--- a/initializers/actions.js
+++ b/initializers/actions.js
@@ -24,8 +24,7 @@ module.exports = {
     
     api.actions.validateAction = function(action){
       var fail = function(msg){
-        api.log(msg + '; exiting.', 'emerg');
-        process.exit();
+        return next( new Error(msg) )
       }
 
       if(action.inputs === undefined){

--- a/initializers/servers.js
+++ b/initializers/servers.js
@@ -63,7 +63,8 @@ module.exports = {
       started++;
       if(api.config.servers[server] && api.config.servers[server].enabled === true){
         api.log('starting server: ' + server, 'notice');
-        api.servers.servers[server].start(function(){
+        api.servers.servers[server].start(function(error){
+          if(error){ return next(error); }
           process.nextTick(function(){
             started--;
             if(started === 0){ next() }
@@ -85,7 +86,8 @@ module.exports = {
       started++;
       (function(server){
         api.log('stopping server: ' + server, 'notice');
-        api.servers.servers[server].stop(function(){
+        api.servers.servers[server].stop(function(error){
+          if(error){ return next(error); }
           process.nextTick(function(){
             api.log('server stopped: ' + server, 'debug');
             started--;

--- a/servers/socket.js
+++ b/servers/socket.js
@@ -49,13 +49,13 @@ var initialize = function(api, options, next){
     }
 
     server.server.on('error', function(e){
-      api.log('Cannot start socket server @ ' + options.bindIP + ':' + options.port + '; Exiting.', 'emerg');
-      api.log(e, 'error');
-      process.exit();
+      return next(new Error('Cannot start socket server @ ' + options.bindIP + ':' + options.port + ' => ' + e.message));
     });
     
     server.server.listen(options.port, options.bindIP, function(){
-      next();
+      process.nextTick(function(){
+        next();
+      });
     });
   }
 

--- a/servers/web.js
+++ b/servers/web.js
@@ -26,10 +26,8 @@ var initialize = function(api, options, next){
   var server = new api.genericServer(type, options, attributes);
 
   if(['api', 'file'].indexOf(api.config.servers.web.rootEndpointType) < 0){
-    server.log('api.config.servers.web.rootEndpointType can only be \'api\' or \'file\'', 'emerg');
-    process.exit();
+    throw new Error('api.config.servers.web.rootEndpointType can only be \'api\' or \'file\'');
   }
-
 
   //////////////////////
   // REQUIRED METHODS //
@@ -59,15 +57,13 @@ var initialize = function(api, options, next){
           server.server.listen(options.port, options.bindIP);
         }, 1000)
       }else{
-        server.log('cannot start web server @ ' + options.bindIP + ':' + options.port + '; exiting.', 'emerg');
-        server.log(e, 'error');
-        process.exit(1);
+        return next(new Error('cannot start web server @ ' + options.bindIP + ':' + options.port + ' => ' + e.message));
       }
     });
 
     server.server.listen(options.port, options.bindIP, function(){
       chmodSocket(options.bindIP, options.port);
-      next(server);
+      next();
     });
   }
 


### PR DESCRIPTION
rather than sprinkling `process.exit()` throughout your initializers, it is better to allow all initializer steps (`initializes()`, `start()`, `stop()`) to pass an error callback.  actionhero in turn will stop the process if an error is detected. 

![screen shot 2015-02-25 at 1 03 51 pm](https://cloud.githubusercontent.com/assets/303226/6380517/1712518e-bcef-11e4-90d8-c840c3aa7407.png)

The same logic has been extended to the `start()` methods of servers. 

Also ensured that the exit code of actionhero is `1` when an error occurs. 