### PR TITLE
[HOLD] Remove Original Connection

### DIFF
--- a/actions/cacheTest.js
+++ b/actions/cacheTest.js
@@ -32,18 +32,18 @@ exports.cacheTest = {
     },
   },
 
-  run: function(api, connection, next){
-    var key = 'cacheTest_' + connection.params.key;
-    var value = connection.params.value;
+  run: function(api, data, next){
+    var key = 'cacheTest_' + data.params.key;
+    var value = data.params.value;
 
-    connection.response.cacheTestResults = {};
+    data.response.cacheTestResults = {};
 
     api.cache.save(key, value, 5000, function(err, resp){
-      connection.response.cacheTestResults.saveResp = resp;
+      data.response.cacheTestResults.saveResp = resp;
       api.cache.size(function(err, numberOfCacheObjects){
-        connection.response.cacheTestResults.sizeResp = numberOfCacheObjects;
+        data.response.cacheTestResults.sizeResp = numberOfCacheObjects;
         api.cache.load(key, function(err, resp, expireTimestamp, createdAt, readAt){
-          connection.response.cacheTestResults.loadResp = {
+          data.response.cacheTestResults.loadResp = {
             key: key,
             value: resp,
             expireTimestamp: expireTimestamp,
@@ -51,8 +51,8 @@ exports.cacheTest = {
             readAt: readAt
           };
           api.cache.destroy(key, function(err, resp){
-            connection.response.cacheTestResults.deleteResp = resp;
-            next(connection, true);
+            data.response.cacheTestResults.deleteResp = resp;
+            next(err);
           });
         });
       });

--- a/actions/randomNumber.js
+++ b/actions/randomNumber.js
@@ -5,9 +5,9 @@ exports.randomNumber = {
     randomNumber: 0.123
   },
   
-  run: function(api, connection, next){
-    connection.response.randomNumber = Math.random();
-    next(connection, true);
+  run: function(api, data, next){
+    data.response.randomNumber = Math.random();
+    next(null);
   }
 
 };

--- a/actions/showDocumentation.js
+++ b/actions/showDocumentation.js
@@ -81,8 +81,8 @@ exports.showDocumentation = {
     }
   },
 
-  run: function(api, connection, next){    
-    connection.response.documentation = api.documentation.documentation;
-    next(connection, true);
+  run: function(api, data, next){    
+    data.response.documentation = api.documentation.documentation;
+    next();
   }
 };

--- a/actions/sleepTest.js
+++ b/actions/sleepTest.js
@@ -23,18 +23,20 @@ exports.sleepTest = {
     }
   },
 
-  run: function(api, connection, next){
-    var sleepDuration = connection.params.sleepDuration;
-
+  run: function(api, data, next){
+    var sleepDuration = data.params.sleepDuration;
     var sleepStarted = new Date().getTime();
+    
     setTimeout(function(){
       var sleepEnded = new Date().getTime();
       var sleepDelta = sleepEnded - sleepStarted;
-      connection.response.sleepStarted = sleepStarted;
-      connection.response.sleepEnded = sleepEnded;
-      connection.response.sleepDelta = sleepDelta;
-      connection.response.sleepDuration = sleepDuration;
-      next(connection, true);
+      
+      data.response.sleepStarted  = sleepStarted;
+      data.response.sleepEnded    = sleepEnded;
+      data.response.sleepDelta    = sleepDelta;
+      data.response.sleepDuration = sleepDuration;
+      
+      next();
     }, sleepDuration);
   }
 };

--- a/actions/status.js
+++ b/actions/status.js
@@ -33,17 +33,17 @@ exports.status = {
     }
   },
 
-  run: function(api, connection, next){
-    connection.response.id = api.id;
-    connection.response.actionheroVersion = api.actionheroVersion;
-    var now = new Date().getTime();
-    connection.response.uptime = now - api.bootTime;
+  run: function(api, data, next){
     api.stats.getAll(function(err, stats){
-      connection.response.stats = stats;
       api.tasks.details(function(err, details){
-        connection.response.queues  = details.queues;
-        connection.response.workers = details.workers;
-        next(connection, true);
+        data.response.id                = api.id;
+        data.response.actionheroVersion = api.actionheroVersion;
+        data.response.uptime            = new Date().getTime() - api.bootTime;
+        data.response.stats             = stats;
+        data.response.queues            = details.queues;
+        data.response.workers           = details.workers;
+        
+        next(err);
       });
     });
   }

--- a/bin/templates/action.js
+++ b/bin/templates/action.js
@@ -9,8 +9,11 @@ exports.action = {
 
   inputs: {},
 
-  run: function(api, connection, next){
+  run: function(api, params, response, connection, next){
+    var error = null;
+
     // your logic here
-    next(connection, true);
+    
+    next(error, response, true);
   }
 };

--- a/bin/templates/action.js
+++ b/bin/templates/action.js
@@ -14,6 +14,6 @@ exports.action = {
 
     // your logic here
     
-    next(error, response, true);
+    next(error);
   }
 };

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -53,6 +53,8 @@ module.exports = {
 
       if(status instanceof Error){    
         error = status;
+      }else if(status === 'server_error'){
+        error = api.config.errors.serverErrorMessage();
       }else if(status === 'server_shutting_down'){
         error = api.config.errors.serverShuttingDown();
       }else if(status === 'too_many_requests'){
@@ -256,8 +258,8 @@ module.exports = {
         if(api.config.general.actionDomains === true){
           self.actionDomain = domain.create();
           self.actionDomain.on('error', function(err){
-            api.exceptionHandlers.action(self.actionDomain, err, self, function(connectionError){
-              self.completeAction(connectionError);
+            api.exceptionHandlers.action(self.actionDomain, err, self, function(){
+              self.completeAction('server_error');
             });
           });
           self.actionDomain.run(function(){

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -256,8 +256,8 @@ module.exports = {
         if(api.config.general.actionDomains === true){
           self.actionDomain = domain.create();
           self.actionDomain.on('error', function(err){
-            api.exceptionHandlers.action(self.actionDomain, err, self.connection, function(){
-              self.completeAction();
+            api.exceptionHandlers.action(self.actionDomain, err, self, function(connectionError){
+              self.completeAction(connectionError);
             });
           });
           self.actionDomain.run(function(){

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -5,49 +5,55 @@ module.exports = {
   loadPriority:  430,
   initialize: function(api, next){
 
-    var duplicateCallbackErrorTimeout = 500;
-
-    api.actionProcessor = function(data){
-      if(!data.connection){ throw new Error('data.connection is required') }
-      this.connection = this.buildProxyConnection(data.connection);
-      this.messageCount = this.connection.messageCount
-      this.callback = data.callback;
-      this.missingParams = [];
-      this.validatorErrors = [];
-      this.working = false;
-    }
-
-    api.actionProcessor.prototype.buildProxyConnection = function(connection){
-      var proxyConnection = {};
-      for(var i in connection){
-        if(connection.hasOwnProperty(i)){
-          proxyConnection[i] = connection[i];
-        }
+    api.actionProcessor = function(connection, callback){
+      if(!connection){ 
+        throw new Error('data.connection is required');
       }
-      proxyConnection._originalConnection = connection
-      return proxyConnection;
+
+      this.connection      = connection;
+      this.action          = null;
+      this.toProcess       = true;
+      this.toRender        = true;
+      this.messageCount    = connection.messageCount;
+      this.params          = connection.params;
+      this.callback        = callback;
+      this.missingParams   = [];
+      this.validatorErrors = [];
+      this.actionStartTime = null;
+      this.actionTemplate  = null;
+      this.working         = false;
+      this.response        = {};
+      this.duration        = null;
+      this.actionStatus    = null;
     }
 
     api.actionProcessor.prototype.incrementTotalActions = function(count){
+      var self = this;
       if(!count){ count = 1 }
-      this.connection._originalConnection.totalActions = this.connection._originalConnection.totalActions + count;
+      self.connection.totalActions = self.connection.totalActions + count;
     }
 
     api.actionProcessor.prototype.incrementPendingActions = function(count){
+      var self = this;
       if(!count){ count = 1 }
-      this.connection._originalConnection.pendingActions = this.connection._originalConnection.pendingActions + count;
+      self.connection.pendingActions = self.connection.pendingActions + count;
     }
 
     api.actionProcessor.prototype.getPendingActionCount = function(){
-      return this.connection._originalConnection.pendingActions;
+      var self = this;
+      return self.connection.pendingActions;
     }
 
-    api.actionProcessor.prototype.completeAction = function(status, toRender, actionDomain){
+    api.actionProcessor.prototype.completeAction = function(status){
       var self = this;
-      if(actionDomain){ actionDomain.exit(); }
-      var error = null
+      var error = null;
+      self.actionStatus = String(status);
 
-      if(status === 'server_shutting_down'){
+      if(self.actionDomain){ self.actionDomain.exit(); }  
+
+      if(status instanceof Error){    
+        error = status;
+      }else if(status === 'server_shutting_down'){
         error = api.config.errors.serverShuttingDown();
       }else if(status === 'too_many_requests'){
         error = api.config.errors.tooManyPendingActions();
@@ -59,128 +65,123 @@ module.exports = {
         error = api.config.errors.missingParams(self.missingParams) ;
       }else if(status === 'validator_errors'){
         error = api.config.errors.invalidParams(self.validatorErrors);
+      }else if(status){
+        error = status;
       }
 
-      if(error !== null){
-        if(typeof error === 'string') self.connection.error = new Error( error );
-        else self.connection.error = error;
+      if(error && typeof error === 'string'){
+        error = new Error( error );
       }
-      if(self.connection.error instanceof Error){
-        self.connection.error = String(self.connection.error);
-      }
-      if(self.connection.error && !self.connection.response.error){
-        self.connection.response.error = self.connection.error;
+      if(error && !self.response.error){
+        self.response.error = error;
       }
 
-      if(toRender === null || toRender === undefined){ toRender = true; }
       self.incrementPendingActions(-1);
       api.stats.increment('actions:actionsCurrentlyProcessing', -1);
       self.duration = new Date().getTime() - self.actionStartTime;
 
       process.nextTick(function(){
-        self.connection._originalConnection.action = self.connection.action;
-        self.connection._originalConnection.actionStatus = status;
-        self.connection._originalConnection.error = self.connection.error;
-        self.connection._originalConnection.response = self.connection.response || {};
-
         if(typeof self.callback === 'function'){
-          self.callback(self.connection._originalConnection, toRender, self.messageCount);
+          self.callback(self);
         }
-      });
-
-      var logLevel = 'info';
-      if(self.actionTemplate && self.actionTemplate.logLevel){
-        logLevel = self.actionTemplate.logLevel;
-      }
-      var stringifiedError = '';
-      try {
-        stringifiedError = JSON.stringify(self.connection.error);
-      } catch(e){
-        stringifiedError = String(self.connection.error)
-      }
-      
-      var filteredParams = {}
-      for(var i in self.connection.params){
-        if(api.config.general.filteredParams && api.config.general.filteredParams.indexOf(i) >= 0){
-          filteredParams[i] = '[FILTERED]';
-        }else{
-          filteredParams[i] = self.connection.params[i];
-        }
-      }
-
-      api.log('[ action @ ' + self.connection.type + ' ]', logLevel, {
-        to: self.connection.remoteIP,
-        action: self.connection.action,
-        params: JSON.stringify(filteredParams),
-        duration: self.duration,
-        error: stringifiedError
       });
 
       self.working = false;
+
+      // logging
+      var logLevel = 'info';
+      if(self.actionTemplate && self.actionTemplate.logLevel){
+        logLevel = self.actionTemplate.logLevel;
+      }      
+      
+      var filteredParams = {}
+      for(var i in self.params){
+        if(api.config.general.filteredParams && api.config.general.filteredParams.indexOf(i) >= 0){
+          filteredParams[i] = '[FILTERED]';
+        }else{
+          filteredParams[i] = self.params[i];
+        }
+      }
+
+      var logLine = {
+        to: self.connection.remoteIP,
+        action: self.action,
+        params: JSON.stringify(filteredParams),
+        duration: self.duration,
+      };
+
+      if(error){
+        try {
+          logLine.error = JSON.stringify(error);
+        } catch(e){
+          logLine.error = String(error);
+        }
+      }
+
+      api.log('[ action @ ' + self.connection.type + ' ]', logLevel, logLine);      
     }
 
-    api.actionProcessor.prototype.preProcessAction = function(toProcess, callback){
+    api.actionProcessor.prototype.preProcessAction = function(callback){
       var self = this;
       var priorities = [];
       var processors = [];
+
       for(var p in api.actions.preProcessors) priorities.push(p);
       priorities.sort();
 
-      if(priorities.length === 0) return callback(toProcess);
+      if(priorities.length === 0) return callback(null);
 
       priorities.forEach(function(priority){
         api.actions.preProcessors[priority].forEach(function(processor){
           processors.push(function(next){
-            if(toProcess === true){
-              processor(self.connection, self.actionTemplate, function(connection, localToProcess){
-                self.connection = connection;
-                if(localToProcess !== null){ toProcess = localToProcess; }
-                next();
-              });
-            } else { next(toProcess) }
-          });
-        });
-      });
-
-      processors.push(function(){ callback(toProcess) });
-      async.series(processors);
-    }
-
-    api.actionProcessor.prototype.postProcessAction = function(toRender, callback){
-      var self = this;
-      var priorities = [];
-      var processors = [];
-      for(var p in api.actions.postProcessors) priorities.push(p);
-      priorities.sort();
-
-      if(priorities.length === 0) return callback(toRender);
-
-      priorities.forEach(function(priority){
-        api.actions.postProcessors[priority].forEach(function(processor){
-          processors.push(function(next){
-            processor(self.connection, self.actionTemplate, toRender, function(connection, localToRender){
-              self.connection = connection;
-              if(localToRender !== null){ toRender = localToRender; }
-              next();
+            processor(self, function(error){
+              next(error);
             });
           });
         });
       });
 
-      processors.push(function(){ callback(toRender) });
-      async.series(processors);
+      async.series(processors, function(err){
+        callback(err);
+      });
+    }
+
+    api.actionProcessor.prototype.postProcessAction = function(callback){
+      var self = this;
+      var priorities = [];
+      var processors = [];
+
+      for(var p in api.actions.postProcessors) priorities.push(p);
+      priorities.sort();
+
+      if(priorities.length === 0) return callback(null);
+
+      priorities.forEach(function(priority){
+        api.actions.postProcessors[priority].forEach(function(processor){
+          processors.push(function(next){
+            processor(self, function(error){
+              next(error);
+            });
+          });
+        });
+      });
+
+      async.series(processors, function(err){
+        callback(err);
+      });
     }
 
     api.actionProcessor.prototype.reduceParams = function(){
       var self = this;
+
       if(api.config.general.disableParamScrubbing !== true){
-        for(var p in self.connection.params){
+        for(var p in self.params){
           if(
               api.params.globalSafeParams.indexOf(p) < 0 &&
               self.actionTemplate.inputs &&
               Object.keys(self.actionTemplate.inputs).indexOf(p) < 0
           ){
-            delete self.connection.params[p];
+            delete self.params[p];
           }
         }
       }
@@ -188,26 +189,27 @@ module.exports = {
 
     api.actionProcessor.prototype.validateParams = function(){
       var self = this;
+
       for(var key in self.actionTemplate.inputs){
         var props = self.actionTemplate.inputs[key];
 
         // default
-        if(self.connection.params[key] === undefined && props.default !== undefined){
+        if(self.params[key] === undefined && props.default !== undefined){
           if(typeof props.default === 'function'){
-            self.connection.params[key] = props.default(self.connection.params[key], self.connection, self.actionTemplate);
+            self.params[key] = props.default(self.params[key], self);
           }else{
-            self.connection.params[key] = props.default;
+            self.params[key] = props.default;
           }
         }
 
         // formatter
-        if(self.connection.params[key] !== undefined && typeof props.formatter === 'function'){
-          self.connection.params[key] = props.formatter(self.connection.params[key], self.connection, self.actionTemplate);
+        if(self.params[key] !== undefined && typeof props.formatter === 'function'){
+          self.params[key] = props.formatter(self.params[key], self);
         }
 
         // validator
-        if(self.connection.params[key] !== undefined && typeof props.validator === 'function'){
-          var validatorResponse = props.validator(self.connection.params[key], self.connection, self.actionTemplate);
+        if(self.params[key] !== undefined && typeof props.validator === 'function'){
+          var validatorResponse = props.validator(self.params[key], self);
           if(validatorResponse !== true){
             self.validatorErrors.push(validatorResponse);
           }
@@ -215,23 +217,10 @@ module.exports = {
 
         // required
         if(props.required === true){
-          if( api.config.general.missingParamChecks.indexOf(self.connection.params[key]) >= 0){
+          if( api.config.general.missingParamChecks.indexOf(self.params[key]) >= 0){
             self.missingParams.push(key);
           }
         }
-      }
-    }
-
-    api.actionProcessor.prototype.duplicateCallbackHandler = function(actionDomain){
-      var self = this;
-      if(self.working === true){
-        setTimeout(function(){
-          self.duplicateCallbackHandler(actionDomain);
-        }, duplicateCallbackErrorTimeout)
-      }else{
-        process.nextTick(function(){
-          api.exceptionHandlers.action(actionDomain, new Error( api.config.errors.doubleCallbackError() ), self.connection);
-        });
       }
     }
 
@@ -241,13 +230,13 @@ module.exports = {
       self.working = true;
       self.incrementTotalActions();
       self.incrementPendingActions();
+      self.action = self.params.action;
 
-      self.connection.action = self.connection.params.action;
-      if(api.actions.versions[self.connection.action]){
-        if(!self.connection.params.apiVersion){
-          self.connection.params.apiVersion = api.actions.versions[self.connection.action][api.actions.versions[self.connection.action].length - 1];
+      if(api.actions.versions[self.action]){
+        if(!self.params.apiVersion){
+          self.params.apiVersion = api.actions.versions[self.action][api.actions.versions[self.action].length - 1];
         }
-        self.actionTemplate = api.actions.actions[self.connection.action][self.connection.params.apiVersion];
+        self.actionTemplate = api.actions.actions[self.action][self.params.apiVersion];
       }
       api.stats.increment('actions:actionsCurrentlyProcessing');
 
@@ -255,11 +244,8 @@ module.exports = {
         self.completeAction('server_shutting_down');
       } else if(self.getPendingActionCount(self.connection) > api.config.general.simultaneousActions){
         self.completeAction('too_many_requests');
-      } else if(self.connection.error !== null){
-        self.completeAction(false);
-      } else if(!self.connection.action || !self.actionTemplate){
+      } else if(!self.action || !self.actionTemplate){
         api.stats.increment('actions:actionsNotFound');
-        if(self.connection.action === '' || !self.connection.action){ self.connection.action = '{no action}'; }
         self.completeAction('unknown_action');
       } else if(self.actionTemplate.blockedConnectionTypes && self.actionTemplate.blockedConnectionTypes.indexOf(self.connection.type) >= 0){
         self.completeAction('unsupported_server_type');
@@ -268,13 +254,13 @@ module.exports = {
         api.stats.increment('actions:processedActions:' + self.connection.action);
 
         if(api.config.general.actionDomains === true){
-          var actionDomain = domain.create();
-          actionDomain.on('error', function(err){
-            api.exceptionHandlers.action(actionDomain, err, self.connection, function(){
-              self.completeAction('server_error', true, actionDomain);
+          self.actionDomain = domain.create();
+          self.actionDomain.on('error', function(err){
+            api.exceptionHandlers.action(self.actionDomain, err, self.connection, function(){
+              self.completeAction();
             });
           });
-          actionDomain.run(function(){
+          self.actionDomain.run(function(){
             self.runAction();
           });
         }else{
@@ -284,34 +270,31 @@ module.exports = {
       }
     }
 
-    api.actionProcessor.prototype.runAction = function(actionDomain){
+    api.actionProcessor.prototype.runAction = function(){
       var self = this;
-      var toProcess = true;
-      var callbackCount = 0;
-      self.preProcessAction(toProcess, function(toProcess){
 
+      self.preProcessAction(function(error){
         self.reduceParams();
         self.validateParams();
 
-        if(self.missingParams.length > 0){
+        if(error){
+          self.completeAction(error);
+        }else if(self.missingParams.length > 0){
           self.completeAction('missing_params');
         }else if(self.validatorErrors.length > 0){
           self.completeAction('validator_errors');
-        }else if(toProcess === true && self.connection.error === null){
-          self.actionTemplate.run(api, self.connection, function(connection, toRender){
-            callbackCount++;
-            if(callbackCount !== 1){
-              callbackCount = 1;
-              self.duplicateCallbackHandler(actionDomain);
+        }else if(self.toProcess === true && !error){
+          self.actionTemplate.run(api, self, function(error){
+            if(error){
+              self.completeAction(error);
             }else{
-              self.connection = connection;
-              self.postProcessAction(toRender, function(toRender){
-                self.completeAction(true, toRender, actionDomain);
+              self.postProcessAction(function(error){
+                self.completeAction(error);
               });
             }
           });
         }else{
-          self.completeAction(false, true, actionDomain);
+          self.completeAction();
         }
       });
     }

--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -109,7 +109,6 @@ module.exports = {
         fingerprint: null,
         rooms: [],
         params: {},
-        response: {},
         pendingActions: 0,
         totalActions: 0,
         messageCount: 0,

--- a/initializers/exceptions.js
+++ b/initializers/exceptions.js
@@ -89,8 +89,7 @@ module.exports = {
       api.stats.increment('exceptions:actions:' + simpleName);    
       api.exceptionHandlers.report(err, 'action', name, {connection: data.connection}, 'error');
       data.connection.response = {}; // no partial responses
-      var connectionError = new Error( api.config.errors.serverErrorMessage() );
-      if(typeof next === 'function'){ next(connectionError); }
+      if(typeof next === 'function'){ next(); }
     };
 
     api.exceptionHandlers.task = function(err, queue, task, workerId){

--- a/initializers/exceptions.js
+++ b/initializers/exceptions.js
@@ -77,20 +77,20 @@ module.exports = {
       api.exceptionHandlers.report(err, 'loader', name, {fullFilePath: fullFilePath}, 'alert');
     };
 
-    api.exceptionHandlers.action = function(domain, err, connection, next){
+    api.exceptionHandlers.action = function(domain, err, data, next){
       var simpleName;
       try{
-        simpleName = connection.action;
+        simpleName = data.connection.action;
       }catch(e){
         simpleName = err.message;
       }
       var name = 'action:' + simpleName;
       api.stats.increment('exceptions:actions');
       api.stats.increment('exceptions:actions:' + simpleName);    
-      api.exceptionHandlers.report(err, 'action', name, {connection: connection}, 'error');
-      connection.error = new Error( api.config.errors.serverErrorMessage() );
-      connection.response = {}; // no partial responses
-      if(typeof next === 'function'){ next(connection, true); }
+      api.exceptionHandlers.report(err, 'action', name, {connection: data.connection}, 'error');
+      data.connection.response = {}; // no partial responses
+      var connectionError = new Error( api.config.errors.serverErrorMessage() );
+      if(typeof next === 'function'){ next(connectionError); }
     };
 
     api.exceptionHandlers.task = function(err, queue, task, workerId){

--- a/initializers/genericServer.js
+++ b/initializers/genericServer.js
@@ -84,12 +84,11 @@ module.exports = {
     
     api.genericServer.prototype.processAction = function(connection){
       var self = this;
-      var actionProcessor = new api.actionProcessor({
-        connection: connection,
-        callback: function(connection, toRender, messageCount){
-          self.emit('actionComplete', connection, toRender, messageCount);
-        }
+      var actionProcessor = new api.actionProcessor(connection,
+      function(data){
+        self.emit('actionComplete', data);
       });
+
       actionProcessor.processAction();
     }
 

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -74,22 +74,27 @@ module.exports = {
           connection.actionCallbacks = {};
         });
 
-        server.on('actionComplete', function(connection, toRender, messageCount){
-          connection.response.messageCount = messageCount;
-          connection.response.serverInformation = {
+        server.on('actionComplete', function(data){
+          data.response.messageCount = data.messageCount;
+          data.response.serverInformation = {
             serverName:      api.config.general.serverName,
             apiVersion:      api.config.general.apiVersion,
           };
-          connection.response.requesterInformation = {
-            id: connection.id,
-            remoteIP: connection.remoteIP,
+          data.response.requesterInformation = {
+            id: data.connection.id,
+            remoteIP: data.connection.remoteIP,
             receivedParams: {}
           };
-          for(var k in connection.params){
-            connection.response.requesterInformation.receivedParams[k] = connection.params[k];
+
+          if(data.response.error instanceof Error){   
+            data.response.error = 'Error: ' + data.response.error.message; 
           }
-          if(toRender === true){
-            server.sendMessage(connection, connection.response, messageCount);
+
+          for(var k in data.params){
+            data.response.requesterInformation.receivedParams[k] = data.params[k];
+          }
+          if(data.toRender === true){
+            server.sendMessage(data.connection, data.response, data.messageCount);
           }
         });
 

--- a/servers/socket.js
+++ b/servers/socket.js
@@ -139,10 +139,10 @@ var initialize = function(api, options, next){
     });
   });
 
-  server.on('actionComplete', function(connection, toRender, messageCount){
-    if(toRender === true){
-      connection.response.context = 'response';
-      server.sendMessage(connection, connection.response, messageCount);
+  server.on('actionComplete', function(data){
+    if(data.toRender === true){
+      data.connection.response.context = 'response';
+      server.sendMessage(data.connection, data.connection.response, data.messageCount);
     }
   });
 

--- a/servers/socket.js
+++ b/servers/socket.js
@@ -64,6 +64,12 @@ var initialize = function(api, options, next){
   }
 
   server.sendMessage = function(connection, message, messageCount){
+    if(message.error && message.error instanceof Error){
+      try{ 
+        message.error = String( message.error.message ); 
+      }catch(e){ }
+    }
+
     if(connection.respondingTo){
       message.messageCount = messageCount;
       connection.respondingTo = null;
@@ -141,8 +147,8 @@ var initialize = function(api, options, next){
 
   server.on('actionComplete', function(data){
     if(data.toRender === true){
-      data.connection.response.context = 'response';
-      server.sendMessage(data.connection, data.connection.response, data.messageCount);
+      data.response.context = 'response';
+      server.sendMessage(data.connection, data.response, data.messageCount);
     }
   });
 

--- a/servers/web.js
+++ b/servers/web.js
@@ -257,14 +257,14 @@ var initialize = function(api, options, next){
           data.connection.rawConnection.responseHeaders.push(['Content-Type', Mime.lookup(data.connection.extension)]);
       }
 
-      var stringResponse = '';
-
-      try{ 
-        data.response.error = data.response.error.message; 
-      }catch(e){
-        data.response.error = String( data.response.error.message ); 
+      if(data.response.error){
+        try{ 
+          data.response.error = String( data.response.error.message ); 
+        }catch(e){ }
       }
       
+      var stringResponse = '';
+
       if( extractHeader(data.connection, 'Content-Type').match(/json/) ){
         stringResponse = JSON.stringify(data.response, null, api.config.servers.web.padding);
         if(data.params.callback){

--- a/servers/web.js
+++ b/servers/web.js
@@ -140,8 +140,8 @@ var initialize = function(api, options, next){
     });
   });
 
-  server.on('actionComplete', function(connection, toRender, messageCount){
-    completeResponse(connection, toRender, messageCount);
+  server.on('actionComplete', function(data){
+    completeResponse(data);
   });
 
   /////////////
@@ -217,59 +217,65 @@ var initialize = function(api, options, next){
     });
   }
 
-  var completeResponse = function(connection, toRender){
-    if(toRender === true){
+  var completeResponse = function(data){
+    if(data.toRender === true){
       if(api.config.servers.web.metadataOptions.serverInformation){
         var stopTime = new Date().getTime();
-        connection.response.serverInformation = {
+        data.response.serverInformation = {
           serverName:      api.config.general.serverName,
           apiVersion:      api.config.general.apiVersion,
-          requestDuration: (stopTime - connection.connectedAt),
+          requestDuration: (stopTime - data.connection.connectedAt),
           currentTime:     stopTime
         };
       }
 
       if(api.config.servers.web.metadataOptions.requesterInformation){
-        connection.response.requesterInformation = buildRequesterInformation(connection);
+        data.response.requesterInformation = buildRequesterInformation(data.connection);
       }
 
-      if(connection.response.error !== undefined){
-        if(api.config.servers.web.returnErrorCodes === true && connection.rawConnection.responseHttpCode === 200){
-          if(connection.actionStatus === 'unknown_action'){
-            connection.rawConnection.responseHttpCode = 404;
-          }else if(connection.actionStatus === 'missing_params'){
-            connection.rawConnection.responseHttpCode = 422;
-          }else if(connection.actionStatus === 'server_error'){
-            connection.rawConnection.responseHttpCode = 500;
+      if(data.response.error){
+        if(api.config.servers.web.returnErrorCodes === true && data.connection.rawConnection.responseHttpCode === 200){
+          if(data.actionStatus === 'unknown_action'){
+            data.connection.rawConnection.responseHttpCode = 404;
+          }else if(data.actionStatus === 'missing_params'){
+            data.connection.rawConnection.responseHttpCode = 422;
+          }else if(data.actionStatus === 'server_error'){
+            data.connection.rawConnection.responseHttpCode = 500;
           }else{
-            connection.rawConnection.responseHttpCode = 400;
+            data.connection.rawConnection.responseHttpCode = 400;
           }
         }
       }
 
       if(
-          (connection.response.error === null || connection.response.error === undefined ) &&
-          connection.action &&
-          connection.params.apiVersion &&
-          api.actions.actions[connection.action][connection.params.apiVersion].matchExtensionMimeType === true &&
-          connection.extension
+          !data.response.error &&
+          data.action &&
+          data.params.apiVersion &&
+          api.actions.actions[data.params.action][data.params.apiVersion].matchExtensionMimeType === true &&
+          data.connection.extension
         ){
-          connection.rawConnection.responseHeaders.push(['Content-Type', Mime.lookup(connection.extension)]);
+          data.connection.rawConnection.responseHeaders.push(['Content-Type', Mime.lookup(data.connection.extension)]);
       }
 
       var stringResponse = '';
 
-      if( extractHeader(connection, 'Content-Type').match(/json/) ){
-        stringResponse = JSON.stringify(connection.response, null, api.config.servers.web.padding);
-        if(connection.params.callback){
-          connection.rawConnection.responseHeaders.push(['Content-Type', 'application/javascript']);
-          stringResponse = connection.params.callback + '(' + stringResponse + ');';
+      try{ 
+        data.response.error = data.response.error.message; 
+      }catch(e){
+        data.response.error = String( data.response.error.message ); 
+      }
+      
+      if( extractHeader(data.connection, 'Content-Type').match(/json/) ){
+        stringResponse = JSON.stringify(data.response, null, api.config.servers.web.padding);
+        if(data.params.callback){
+          data.connection.rawConnection.responseHeaders.push(['Content-Type', 'application/javascript']);
+          stringResponse = data.connection.params.callback + '(' + stringResponse + ');';
         }
       }else{
-        stringResponse = connection.response;
+        stringResponse = data.response;
       }
 
-      server.sendMessage(connection, stringResponse);
+      server.sendMessage(data.connection, stringResponse);
     }
   }
 

--- a/servers/websocket.js
+++ b/servers/websocket.js
@@ -113,10 +113,10 @@ var initialize = function(api, options, next){
     });
   });
 
-  server.on('actionComplete', function(connection, toRender, messageCount){
-    if(toRender !== false){
-      connection.response.messageCount = messageCount;
-      server.sendMessage(connection, connection.response, messageCount)
+  server.on('actionComplete', function(data){
+    if(data.toRender !== false){
+      data.connection.response.messageCount = data.messageCount;
+      server.sendMessage(data.connection, data.response, data.messageCount)
     }
   });
 

--- a/servers/websocket.js
+++ b/servers/websocket.js
@@ -68,6 +68,12 @@ var initialize = function(api, options, next){
   }
 
   server.sendMessage = function(connection, message, messageCount){
+    if(message.error && message.error instanceof Error){
+      try{ 
+        message.error = String( message.error.message ); 
+      }catch(e){ }
+    }
+    
     if(!message.context){ message.context = 'response'; }
     if(!messageCount){ messageCount = connection.messageCount; }
     if(message.context === 'response' && !message.messageCount){ message.messageCount = messageCount; }

--- a/tasks/runAction.js
+++ b/tasks/runAction.js
@@ -17,8 +17,8 @@ var task = {
     
     connection.params = params;
 
-    var actionProcessor = new api.actionProcessor({connection: connection, callback: function(connection){
-      if(connection.error){
+    var actionProcessor = new api.actionProcessor(connection, function(error){
+      if(error){
         api.log('task error: ' + connection.error, 'error', {params: JSON.stringify(params)});
       } else {
         api.log('[ action @ task ]', 'debug', {params: JSON.stringify(params)});
@@ -30,7 +30,7 @@ var task = {
       connection.destroy(function(){
         next(error, response);
       });
-    }});
+    });
     
     actionProcessor.processAction();
   }

--- a/tasks/runAction.js
+++ b/tasks/runAction.js
@@ -17,18 +17,15 @@ var task = {
     
     connection.params = params;
 
-    var actionProcessor = new api.actionProcessor(connection, function(error){
-      if(error){
-        api.log('task error: ' + connection.error, 'error', {params: JSON.stringify(params)});
+    var actionProcessor = new api.actionProcessor(connection, function(data){
+      if(data.response.error){
+        api.log('task error: ' + data.response.error, 'error', {params: JSON.stringify(params)});
       } else {
         api.log('[ action @ task ]', 'debug', {params: JSON.stringify(params)});
       }
 
-      var error    = connection.error;
-      var response = connection.response;
-
       connection.destroy(function(){
-        next(error, response);
+        next(data.response.error, data.response);
       });
     });
     

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -150,68 +150,6 @@ describe('Core: API', function(){
         done();
       });
     });
-  })
-
-  describe('duplicate callback prevention', function(){
-
-    before(function(done){
-      api.actions.versions.badAction = [1]
-      api.actions.actions.badAction = {
-        '1': {
-          name: 'badAction',
-          description: 'I double callback',
-          version: 1,
-          outputExample: {},
-          run:function(api, connection, next){
-            connection.response.count = 1
-            next(connection, true);
-            setTimeout(function(){
-              connection.response.count = 2
-              next(connection, true);
-            }, 1000)
-          }
-        }
-      }
-      done();
-    });
-
-    after(function(done){
-      api.actions.preProcessors = {};
-      delete api.actions.actions.badAction;
-      delete api.actions.versions.badAction;
-      done();
-    });
-
-    it('will only callback once for a bad action and only the first response will be returned', function(done){
-      var responses = [];
-      api.specHelper.runAction('badAction', function(response){
-        responses.push( api.utils.objClone(response) );
-      });
-
-      setTimeout(function(){
-        responses.length.should.equal(1);
-        responses[0].count.should.equal(1)
-        done();
-      }, 2000)
-    });
-
-    it('can also prevent double callbacks from middleware', function(done){
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        next(connection, true);
-        next(connection, true);
-      });
-
-      var responses = [];
-      api.specHelper.runAction('randomNumber', function(response){
-        responses.push( api.utils.objClone(response) );
-      });
-
-      setTimeout(function(){
-        responses.length.should.equal(1);
-        done();
-      }, 2000)
-    });
-
   });
 
   describe('Action Params', function(){

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -95,12 +95,12 @@ describe('Core: API', function(){
           description: 'I am a test',
           version: 3,
           outputExample: {},
-          run:function(api, connection, next){
-            connection.response.version = 1;
-            connection.error = {
+          run:function(api, data, next){
+            data.response.version = 1;
+            var error = {
               'a' : {'complex': 'error'}
             }
-            next(connection, true);
+            next(error);
           }
         }
       }

--- a/test/core/binary.js
+++ b/test/core/binary.js
@@ -126,7 +126,7 @@ describe('Core: Binary', function(){
       var data = String( fs.readFileSync(testDir + '/actions/myAction.js') );
       data.should.containEql('name:                   \'myAction\'');
       data.should.containEql('description:            \'my_description\'');
-      data.should.containEql('next(connection, true)');
+      data.should.containEql('next(error);');
       done();
     });
   });

--- a/test/core/exceptions.js
+++ b/test/core/exceptions.js
@@ -42,7 +42,7 @@ describe('Core: Exceptions', function(){
         version: 1,
         run: function(api, connection, next){
           thing // undefined
-          next(connection, true);
+          next();
         }
       }
     }
@@ -52,31 +52,10 @@ describe('Core: Exceptions', function(){
   });
 
   it('the bad action should fail gracefully', function(done){
-    /**
-     * @nullivex
-     * This test in particular is interesting because of the way it expects
-     * mocha to handle and rethrow the exception.
-     *
-     * Implementing grunt and grunt-mocha-test will run this code inside a domain
-     * and the action runner also creates a domain so they are nested. In node ~0.8.9
-     * this seems to cause the exception to land in mocha's lap rather than being
-     * rethrown to the child domain.
-     *
-     * I believe this works fine in node ~0.9.0 because they ironed out some of the
-     * issues especially with nested domains and how exceptions are bubbled in those
-     * environments there is an issue about this here: https://github.com/joyent/node/issues/4375
-     *
-     * So, it is best just to ignore this test in node ~0.8.9 and below and it should
-     * still pass in normal environments.
-     */
-    if(9 < parseInt(process.version.split('.')[1],10) && api.config.general.actionDomains === true){
-      api.specHelper.runAction('badAction', {}, function(response){
-        response.error.should.equal('Error: The server experienced an internal error');
-        done();
-      });
-    } else {
-      done()
-    }
+    api.specHelper.runAction('badAction', {}, function(response){
+      response.error.should.equal('Error: The server experienced an internal error');
+      done();
+    });
   });
 
   it('other actions still work', function(done){

--- a/test/core/exceptions.js
+++ b/test/core/exceptions.js
@@ -52,10 +52,14 @@ describe('Core: Exceptions', function(){
   });
 
   it('the bad action should fail gracefully', function(done){
-    api.specHelper.runAction('badAction', {}, function(response){
-      response.error.should.equal('Error: The server experienced an internal error');
+    if(api.config.general.actionDomains === true){
+      api.specHelper.runAction('badAction', {}, function(response){
+        response.error.should.equal('Error: The server experienced an internal error');
+        done();
+      });
+    }else{
       done();
-    });
+    }
   });
 
   it('other actions still work', function(done){

--- a/test/core/middleware.js
+++ b/test/core/middleware.js
@@ -27,9 +27,9 @@ describe('Core: Middleware', function(){
   describe('action preProcessors', function(){
 
     it('I can define an action preProcessor and it can append the connection', function(done){
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._preProcessorNote = 'note'
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._preProcessorNote = 'note'
+        next();
       });
 
       api.specHelper.runAction('randomNumber', function(response){
@@ -40,33 +40,33 @@ describe('Core: Middleware', function(){
     
     it('preProcessors with priorities run in the right order', function(done){
       // first priority
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._processorNoteFirst = 'first';
-        connection.response._processorNoteEarly = 'first';
-        connection.response._processorNoteLate = 'first';
-        connection.response._processorNoteDefault = 'first';
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._processorNoteFirst = 'first';
+        data.response._processorNoteEarly = 'first';
+        data.response._processorNoteLate = 'first';
+        data.response._processorNoteDefault = 'first';
+        next();
       }, 1);
       
       // lower number priority (runs sooner)
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._processorNoteEarly = 'early';
-        connection.response._processorNoteLate = 'early';
-        connection.response._processorNoteDefault = 'early';
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._processorNoteEarly = 'early';
+        data.response._processorNoteLate = 'early';
+        data.response._processorNoteDefault = 'early';
+        next();
       }, api.config.general.defaultProcessorPriority-1);
       
       // old style "default" priority
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._processorNoteLate = 'default';
-        connection.response._processorNoteDefault = 'default';
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._processorNoteLate = 'default';
+        data.response._processorNoteDefault = 'default';
+        next();
       });
       
       // higher number priority (runs later)
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._processorNoteLate = 'late';
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._processorNoteLate = 'late';
+        next();
       }, api.config.general.defaultProcessorPriority+1);
       
       api.specHelper.runAction('randomNumber', function(response){
@@ -79,14 +79,14 @@ describe('Core: Middleware', function(){
     });
     
     it('multiple preProcessors with same priority are executed', function(done){
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._processorNoteFirst = 'first';
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._processorNoteFirst = 'first';
+        next();
       }, api.config.general.defaultProcessorPriority-1);
       
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.response._processorNoteSecond = 'second';
-        next(connection, true);
+      api.actions.addPreProcessor(function(data, next){
+        data.response._processorNoteSecond = 'second';
+        next();
       }, api.config.general.defaultProcessorPriority-1);
       
       api.specHelper.runAction('randomNumber', function(response){
@@ -97,9 +97,9 @@ describe('Core: Middleware', function(){
     });
 
     it('postProcessors can append the connection', function(done){
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._postProcessorNote = 'note'
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._postProcessorNote = 'note'
+        next();
       });
 
       api.specHelper.runAction('randomNumber', function(response){
@@ -110,33 +110,33 @@ describe('Core: Middleware', function(){
 
     it('postProcessors with priorities run in the right order', function(done){
       // first priority
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._processorNoteFirst = 'first';
-        connection.response._processorNoteEarly = 'first';
-        connection.response._processorNoteLate = 'first';
-        connection.response._processorNoteDefault = 'first';
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._processorNoteFirst = 'first';
+        data.response._processorNoteEarly = 'first';
+        data.response._processorNoteLate = 'first';
+        data.response._processorNoteDefault = 'first';
+        next();
       }, 1);
       
       // lower number priority (runs sooner)
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._processorNoteEarly = 'early';
-        connection.response._processorNoteLate = 'early';
-        connection.response._processorNoteDefault = 'early';
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._processorNoteEarly = 'early';
+        data.response._processorNoteLate = 'early';
+        data.response._processorNoteDefault = 'early';
+        next();
       }, api.config.general.defaultProcessorPriority-1);
       
       // old style "default" priority
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._processorNoteLate = 'default';
-        connection.response._processorNoteDefault = 'default';
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._processorNoteLate = 'default';
+        data.response._processorNoteDefault = 'default';
+        next();
       });
       
       // higher number priority (runs later)
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._processorNoteLate = 'late';
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._processorNoteLate = 'late';
+        next();
       }, api.config.general.defaultProcessorPriority+1);
       
       api.specHelper.runAction('randomNumber', function(response){
@@ -149,14 +149,14 @@ describe('Core: Middleware', function(){
     });
     
     it('multiple postProcessors with same priority are executed', function(done){
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._processorNoteFirst = 'first';
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._processorNoteFirst = 'first';
+        next();
       }, api.config.general.defaultProcessorPriority-1);
       
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        connection.response._processorNoteSecond = 'second';
-        next(connection, true);
+      api.actions.addPostProcessor(function(data, next){
+        data.response._processorNoteSecond = 'second';
+        next();
       }, api.config.general.defaultProcessorPriority-1);
       
       api.specHelper.runAction('randomNumber', function(response){
@@ -167,21 +167,21 @@ describe('Core: Middleware', function(){
     });
 
     it('preProcessors can block actions', function(done){
-      api.actions.addPreProcessor(function(connection, actionTemplate, next){
-        connection.error = 'BLOCKED'
-        next(connection, false);
+      api.actions.addPreProcessor(function(data, next){
+        next(new Error( 'BLOCKED' ));
       });
 
-      api.specHelper.runAction('randomNumber', function(response, connection){
-        connection.error.should.equal('BLOCKED');
-        should.not.exist(connection.randomNumber);
+      api.specHelper.runAction('randomNumber', function(response){
+        response.error.should.equal('Error: BLOCKED');
+        should.not.exist(response.randomNumber);
         done();
       });
     })
 
     it('postProcessors can modify toRender', function(done){
-      api.actions.addPostProcessor(function(connection, actionTemplate, toRender, next){
-        next(connection, false);
+      api.actions.addPostProcessor(function(data, next){
+        data.toRender = false;
+        next();
       });
 
       api.specHelper.runAction('randomNumber', function(){
@@ -189,7 +189,7 @@ describe('Core: Middleware', function(){
       });
       setTimeout(function(){
         done();
-      }, 500);
+      }, 1000);
     })
   
   })

--- a/test/servers/socket.js
+++ b/test/servers/socket.js
@@ -71,7 +71,7 @@ describe('Server: Socket', function(){
   it('socket connections should be able to connect and get JSON', function(done){
     makeSocketRequest(client, 'hello', function(response){
       response.should.be.an.instanceOf(Object)
-      response.error.should.equal('Error: unknown action or invalid apiVersion');
+      response.error.should.equal('unknown action or invalid apiVersion');
       done();
     });
   });
@@ -131,7 +131,7 @@ describe('Server: Socket', function(){
   it('actions will fail without proper params set to the connection', function(done){
     makeSocketRequest(client, 'paramDelete key', function(){
       makeSocketRequest(client, 'cacheTest', function(response){
-        response.error.should.equal('Error: key is a required parameter for this action')
+        response.error.should.equal('key is a required parameter for this action')
         done();
       });
     });
@@ -181,7 +181,7 @@ describe('Server: Socket', function(){
 
   it('only params sent in a JSON block are used', function(done){
     makeSocketRequest(client, JSON.stringify({action: 'cacheTest', params: {key: 'someOtherValue'}}), function(response){
-      response.error.should.equal('Error: value is a required parameter for this action')
+      response.error.should.equal('value is a required parameter for this action')
       done();
     });
   });
@@ -206,7 +206,7 @@ describe('Server: Socket', function(){
         for(var i in responses){
           var response = responses[i];
           if(i === '0'){
-            response.error.should.eql('Error: you have too many pending requests');
+            response.error.should.eql('you have too many pending requests');
           } else {
             should.not.exist(response.error)
           }

--- a/test/servers/websocket.js
+++ b/test/servers/websocket.js
@@ -88,7 +88,7 @@ describe('Server: Web Socket', function(){
 
   it('can run actions with errors', function(done){
     clientA.action('cacheTest', function(response){
-      response.error.should.equal('Error: key is a required parameter for this action');
+      response.error.should.equal('key is a required parameter for this action');
       done();
     });
   });
@@ -127,7 +127,7 @@ describe('Server: Web Socket', function(){
       for(var i in responses){
         var response = responses[i];
         if(i === 0 || i === '0'){
-          response.error.should.eql('Error: you have too many pending requests');
+          response.error.should.eql('you have too many pending requests');
         } else {
           should.not.exist(response.error)
         }


### PR DESCRIPTION
This allows us to remove the notion of `connection._originalConnection` in actions/middleware.  This simplifies the code and allows for expected behavior (modifying `connection` will persist) to occur.

This PR drastically changes the APIs of actions and middleware.  

# Actions

Action Syntax now looks like this: 

```js
run: function(api, data, next){
  data.response.randomNumber = Math.random();
  next(error);
}
```

Where data contains:

```
data = {
  connection: connection,
  action: 'randomNumber',
  toProcess: true,
  toRender: true,
  messageCount: 123,
  params: { action: 'randomNumber', apiVersion: 1 },
  actionStartTime: 123,
  response: {},
}
```

Now, when you run an action, you modify `data.response`.  If there is an error, you callback to `next(err)` with it.

If you don't want to `toRender`, just set it to false: `data.toRender = false` within the action.

# Servers

When building custom servers, the response to an action is now:

```js
server.on('actionComplete', function(data){
  completeResponse(data);
});
```

Where data is the same as in the action.  Note that `data.toRender` should be inspected here.  Any errors will be located in `data.response.error`.

# Midleware (action)

Similar to actions, the syntax becomes:

```js
api.actions.addPreProcessor(function(data, next){
  if(data.params.userId == null){
    var error = new Error( "All actions require a userId" );
    next(error);
  }else{
    next();
  }
});
```

## Misc:

- This PR removes duplicate callback prevention.  This belongs on the user/implementer to handle. 

--- 

This will solve https://github.com/evantahler/actionhero/issues/561