### PR TITLE
Clean up templates.

### DIFF
--- a/bin/templates/gruntfile.js
+++ b/bin/templates/gruntfile.js
@@ -1,2 +1,2 @@
-var grunt = require('grunt')
-require('actionhero/grunt')(grunt)
+var grunt = require('grunt');
+require('actionhero/grunt')(grunt);

--- a/bin/templates/initializer.js
+++ b/bin/templates/initializer.js
@@ -13,4 +13,4 @@ module.exports = {
   stop: function(api, next){
     next();
   }
-}
+};

--- a/bin/templates/server.js
+++ b/bin/templates/server.js
@@ -4,14 +4,15 @@ var initialize = function(api, options, next){
   // INIT //
   //////////
 
-  var type = '%%name%%'
+  var type = '%%name%%';
+
   var attributes = {
     canChat: true,
     logConnections: true,
     logExits: true,
     sendWelcomeMessage: true,
     verbs: []
-  }
+  };
 
   var server = new api.genericServer(type, options, attributes);
 
@@ -21,15 +22,15 @@ var initialize = function(api, options, next){
 
   server.start = function(next){
     next();
-  }
+  };
 
   server.stop = function(next){
     next();
-  }
+  };
 
   server.sendMessage = function(connection, message, messageCount){
 
-  }
+  };
 
   server.sendFile = function(connection, error, fileStream, mime, length){
 
@@ -56,6 +57,6 @@ var initialize = function(api, options, next){
   /////////////
 
   next(server);
-}
+};
 
 exports.initialize = initialize;

--- a/bin/templates/task.js
+++ b/bin/templates/task.js
@@ -5,7 +5,7 @@ exports.task = {
   queue:         '%%queue%%',
   plugins:       [],
   pluginOptions: {},
-  
+
   run: function(api, params, next){
     // your logic here');
     next();


### PR DESCRIPTION
Noticed that generated components have missing semicolons, so decided to update templates to include them, so at least eslint/jslint/jshint has less stuff to complain about.