### PR TITLE
Complex objects as ActionheroClient's webAction() parameters

### DIFF
--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -153,11 +153,11 @@ ActionheroClient.prototype.action = function(action, params, callback){
   }
 }
 
-ActionheroClient.prototype.actionWeb = function (params, callback) {
+ActionheroClient.prototype.actionWeb = function(params, callback) {
   var xmlhttp = new XMLHttpRequest();
   xmlhttp.onreadystatechange = function () {
-    if (xmlhttp.readyState === 4) {
-      if (xmlhttp.status === 200) {
+    if(xmlhttp.readyState === 4) {
+      if(xmlhttp.status === 200) {
         var response = JSON.parse(xmlhttp.responseText);
         callback(null, response);
       } else {
@@ -165,30 +165,12 @@ ActionheroClient.prototype.actionWeb = function (params, callback) {
       }
     }
   };
-
-  var method = typeof params == 'object' ? 'POST' : 'GET';
-  if (params.httpMethod) {
-    method = params.httpMethod;
-  }
-
-  var url = this.options.url + this.options.apiPath + '?';
-  if (method == 'POST') {
-    url += 'action=' + params.action;
-    xmlhttp.open(method, url, true);
-    if (typeof params == 'object') {
-      xmlhttp.setRequestHeader('Content-Type', 'application/json');
-      params = JSON.stringify(params)
-    }
-    xmlhttp.send(params);
-  } else {
-    var qs = '';
-    for (var i in params) {
-      qs += i + '=' + params[i] + '&';
-    }
-    url += qs;
-    xmlhttp.open(method, url, true);
-    xmlhttp.send();
-  }
+  
+  var method = params.httpMethod || 'POST';
+  var url = this.options.url + this.options.apiPath;
+  xmlhttp.open(method, url, true);
+  xmlhttp.setRequestHeader('Content-Type', 'application/json');
+  xmlhttp.send(JSON.stringify(params));	
 }
 
 

--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -167,7 +167,7 @@ ActionheroClient.prototype.actionWeb = function(params, callback) {
   };
   
   var method = params.httpMethod || 'POST';
-  var url = this.options.url + this.options.apiPath;
+  var url = this.options.url + this.options.apiPath + '?action=' + params.action;
   xmlhttp.open(method, url, true);
   xmlhttp.setRequestHeader('Content-Type', 'application/json');
   xmlhttp.send(JSON.stringify(params));	

--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -153,30 +153,44 @@ ActionheroClient.prototype.action = function(action, params, callback){
   }
 }
 
-ActionheroClient.prototype.actionWeb = function(params, callback){
+ActionheroClient.prototype.actionWeb = function (params, callback) {
   var xmlhttp = new XMLHttpRequest();
-  xmlhttp.onreadystatechange = function(){
-    if(xmlhttp.readyState === 4){
-      if(xmlhttp.status === 200){
+  xmlhttp.onreadystatechange = function () {
+    if (xmlhttp.readyState === 4) {
+      if (xmlhttp.status === 200) {
         var response = JSON.parse(xmlhttp.responseText);
         callback(null, response);
-      }else{
+      } else {
         callback(xmlhttp.statusText, xmlhttp.responseText);
       }
     }
-  }
-  var qs = '?';
-  for(var i in params){
-    qs += i + '=' + params[i] + '&';
-  }
-  var method = 'GET';
-  if(params.httpMethod){
+  };
+
+  var method = typeof params == "object" ? "POST" : 'GET';
+  if (params.httpMethod) {
     method = params.httpMethod;
   }
-  var url = this.options.url + this.options.apiPath + qs;
-  xmlhttp.open(method, url, true);
-  xmlhttp.send();
+
+  var url = this.options.url + this.options.apiPath + "?";
+  if (method == "POST") {
+    url += "action=" + params.action;
+    xmlhttp.open(method, url, true);
+    if (typeof params == "object") {
+      xmlhttp.setRequestHeader("Content-Type", "application/json");
+      params = JSON.stringify(params)
+    }
+    xmlhttp.send(params);
+  } else {
+    var qs = '';
+    for (var i in params) {
+      qs += i + '=' + params[i] + '&';
+    }
+    url += qs;
+    xmlhttp.open(method, url, true);
+    xmlhttp.send();
+  }
 }
+
 
 ActionheroClient.prototype.actionWebSocket = function(params, callback){
   this.send({event: 'action',params: params}, callback);

--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -166,17 +166,17 @@ ActionheroClient.prototype.actionWeb = function (params, callback) {
     }
   };
 
-  var method = typeof params == "object" ? "POST" : 'GET';
+  var method = typeof params == 'object' ? 'POST' : 'GET';
   if (params.httpMethod) {
     method = params.httpMethod;
   }
 
-  var url = this.options.url + this.options.apiPath + "?";
-  if (method == "POST") {
-    url += "action=" + params.action;
+  var url = this.options.url + this.options.apiPath + '?';
+  if (method == 'POST') {
+    url += 'action=' + params.action;
     xmlhttp.open(method, url, true);
-    if (typeof params == "object") {
-      xmlhttp.setRequestHeader("Content-Type", "application/json");
+    if (typeof params == 'object') {
+      xmlhttp.setRequestHeader('Content-Type', 'application/json');
       params = JSON.stringify(params)
     }
     xmlhttp.send(params);


### PR DESCRIPTION
When the ActionheroClient makes requests over HTTP, it constructs a string to pass as URL parameters to a GET request. As in:

    for (var i in params) {
        qs += i + '=' + params[i] + '&';
    }

This is troublesome for parameter objects such as:

    { a: { b: 3 } }

I've modified the webAction() to stringify and POST the parameter data if it is an object.

Although thinking now, the parameter argument should *always* be an object, making the original GET request code unnecessary if the new POST code is preferred.