### PR TITLE
add default params to routes

### DIFF
--- a/initializers/routes.js
+++ b/initializers/routes.js
@@ -17,10 +17,8 @@ module.exports = {
           var route = api.routes.routes[method][i];
           var match = api.routes.matchURL(pathParts, route.path);
           if(match.match === true){
-            if(route.params){
-              for(var param in route.params){
-                connection.params[param] = connection.params[param] || route.params[param];
-              }
+            if(route.apiVersion){
+              connection.params.apiVersion = connection.params.apiVersion || route.apiVersion;
             }
             
             for(var param in match.params){
@@ -80,8 +78,8 @@ module.exports = {
     }
 
 
-    api.routes.registerRoute = function(method, path, action, params) {
-      api.routes.routes[method].push({ path: path, action: action, params:params});
+    api.routes.registerRoute = function(method, path, action, apiVersion) {
+      api.routes.routes[method].push({ path: path, action: action, apiVersion:apiVersion});
     }
 
     // load in the routes file
@@ -104,10 +102,10 @@ module.exports = {
           if(method === 'all'){
             for(v in api.routes.verbs){
               verb = api.routes.verbs[v];
-              api.routes.registerRoute(verb, route.path, route.action, route.params);
+              api.routes.registerRoute(verb, route.path, route.action, route.apiVersion);
             }
           } else {
-            api.routes.registerRoute(method, route.path, route.action, route.params);
+            api.routes.registerRoute(method, route.path, route.action, route.apiVersion);
           }
           counter++;
         }

--- a/initializers/routes.js
+++ b/initializers/routes.js
@@ -17,6 +17,12 @@ module.exports = {
           var route = api.routes.routes[method][i];
           var match = api.routes.matchURL(pathParts, route.path);
           if(match.match === true){
+            if(route.params){
+              for(var param in route.params){
+                connection.params[param] = connection.params[param] || route.params[param];
+              }
+            }
+            
             for(var param in match.params){
               try{
                 var decodedName = decodeURIComponent(param.replace(/\+/g, ' '));
@@ -74,8 +80,8 @@ module.exports = {
     }
 
 
-    api.routes.registerRoute = function(method, path, action) {
-      api.routes.routes[method].push({ path: path, action: action });
+    api.routes.registerRoute = function(method, path, action, params) {
+      api.routes.routes[method].push({ path: path, action: action, params:params});
     }
 
     // load in the routes file
@@ -98,10 +104,10 @@ module.exports = {
           if(method === 'all'){
             for(v in api.routes.verbs){
               verb = api.routes.verbs[v];
-              api.routes.registerRoute(verb, route.path, route.action);
+              api.routes.registerRoute(verb, route.path, route.action, route.params);
             }
           } else {
-            api.routes.registerRoute(method, route.path, route.action);
+            api.routes.registerRoute(method, route.path, route.action, route.params);
           }
           counter++;
         }

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -713,8 +713,7 @@ describe('Server: Web', function(){
           { path: '/mimeTestAction/:key', action: 'mimeTestAction' },
           { path: '/thing', action: 'thing' },
           { path: '/thing/stuff', action: 'thingStuff' },
-          { path: '/phil', action: 'login', params:{ userID: '5' } },
-          { path: '/old_login', action: 'login', params:{ apiVersion: '1' } }
+          { path: '/old_login', action: 'login', apiVersion: '1' }
         ],
         post: [
           { path: '/login/:userID(^(\\d{3}|admin)$)', action: 'login' }
@@ -766,26 +765,6 @@ describe('Server: Web', function(){
       request.get(url + '/api/user/123?action=someFakeAction', function(err, response, body){
         body = JSON.parse(body);
         body.requesterInformation.receivedParams.action.should.equal('user')
-        done();
-      });
-    });
-
-    it('Routes should use default params', function(done){
-      request.get(url + '/api/phil', function(err, response, body){
-        body = JSON.parse(body);
-        body.userID.should.equal('5');
-        body.requesterInformation.receivedParams.action.should.equal('login')
-        body.requesterInformation.receivedParams.userID.should.equal('5')
-        done();
-      });
-    });
-    
-    it('Routes should use given params over default', function(done){
-      request.get(url + '/api/phil?userID=10', function(err, response, body){
-        body = JSON.parse(body);
-        body.userID.should.equal('10');
-        body.requesterInformation.receivedParams.action.should.equal('login')
-        body.requesterInformation.receivedParams.userID.should.equal('10')
         done();
       });
     });


### PR DESCRIPTION
Hey,

currently there is no way to add a route (e.g `POST /old_login`) which will target a specific version of an action. The only way to achieve this is to add `?apiVersion=x` to the request, which is problematic if you have for example some legacy mobile apps which can't be updated.

I've added the possibility to define default params for every route:
```js
post:{
  { path: '/old_login', action: 'login', params:{ apiVersion: '1' } }
}
```

this will also work for other params beside `apiVersion`.

Tests are included!