### PR TITLE
exception handler needs action name

### DIFF
--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -226,7 +226,7 @@ module.exports = {
       self.working = true;
       self.incrementTotalActions();
       self.incrementPendingActions();
-      self.action = self.params.action;
+      self.connection.action = self.action = self.params.action;
 
       if(api.actions.versions[self.action]){
         if(!self.params.apiVersion){


### PR DESCRIPTION
there is this line in action exception handler: "simpleName = data.connection.action;"