### PR TITLE
Optionally Enforce connection properties

### DIFF
--- a/config/api.js
+++ b/config/api.js
@@ -22,6 +22,8 @@ exports.default = {
       actionDomains: true,
       // How many pending actions can a single connection be working on
       simultaneousActions: 5,
+      // allow connections to be created without remoteIp and remotePort (they will be set to 0)
+      enforceConnectionProperties: true,
       // disables the whitelisting of client params
       disableParamScrubbing: false,
       // params you would like hidden from any logs

--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -105,13 +105,18 @@ module.exports = {
         self[req] = data[req];
       });
 
-      if(api.config.general.enforceConnectionProperties === true){
-        ['remotePort', 'remoteIP'].forEach(function(req){
-          if(data[req] === null || data[req] === undefined){ throw new Error(req + ' is required to create a new connection object') }
-          self[req] = data[req];
-        });
-      }
       
+      ['remotePort', 'remoteIP'].forEach(function(req){
+        if(data[req] === null || data[req] === undefined){ 
+          if(api.config.general.enforceConnectionProperties === true){
+            throw new Error(req + ' is required to create a new connection object') 
+          }else{
+            data[req] = 0; // could be a random uuid as well?
+          }
+        }
+        self[req] = data[req];
+      });
+
       var connectionDefaults = {
         error: null,
         fingerprint: null,

--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -99,11 +99,19 @@ module.exports = {
         self.id = self.generateID();
       }
       self.connectedAt = new Date().getTime();
-      ['type', 'remotePort', 'remoteIP', 'rawConnection'].forEach(function(req){
+      
+      ['type', 'rawConnection'].forEach(function(req){
         if(data[req] === null || data[req] === undefined){ throw new Error(req + ' is required to create a new connection object') }
         self[req] = data[req];
       });
 
+      if(api.config.general.enforceConnectionProperties === true){
+        ['remotePort', 'remoteIP'].forEach(function(req){
+          if(data[req] === null || data[req] === undefined){ throw new Error(req + ' is required to create a new connection object') }
+          self[req] = data[req];
+        });
+      }
+      
       var connectionDefaults = {
         error: null,
         fingerprint: null,


### PR DESCRIPTION
Make it optional that each new connection has a `remotePort` and `remoteIp`