### PR TITLE
fix: fixes the error when using babel-node under strict mode

### DIFF
--- a/config/redis.js
+++ b/config/redis.js
@@ -1,12 +1,12 @@
-exports.default = { 
+exports.default = {
   redis: function(api){
     var redisDetails = {
       // Which channel to use on redis pub/sub for RPC communication
       channel: 'actionhero',
-      // How long to wait for an RPC call before considering it a failure 
-      rpcTimeout: 5000, 
-      // which redis package should you ise?
-      package: 'fakeredis',
+      // How long to wait for an RPC call before considering it a failure
+      rpcTimeout: 5000,
+      // which redis pkg should you ise?
+      pkg: 'fakeredis',
 
       // Basic configuration options
       host     : process.env.REDIS_HOST || '127.0.0.1',
@@ -15,7 +15,7 @@ exports.default = {
     }
 
     if( process.env.FAKEREDIS === 'false' || process.env.REDIS_HOST !== undefined ){
-      redisDetails.package  = 'ioredis';
+      redisDetails.pkg  = 'ioredis';
       // there are many more connection options, including support for cluster and sentinel
       // learn more @ https://github.com/luin/ioredis
       redisDetails.options  = {
@@ -27,15 +27,15 @@ exports.default = {
   }
 }
 
-exports.test = { 
+exports.test = {
   redis: function(api){
-    var package = 'fakeredis';
+    var pkg = 'fakeredis';
     if(process.env.FAKEREDIS === 'false'){
-      package = 'ioredis';
+      pkg = 'ioredis';
     }
 
     return {
-      package: package,
+      pkg: pkg,
       host: '127.0.0.1',
       port: 6379,
       database: 2,

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -17,21 +17,21 @@ module.exports = {
       calledback: false,
     };
 
-    var redisPackage = require(api.config.redis.package);
-    if(api.config.redis.package === 'fakeredis'){
+    var redisPackage = require(api.config.redis.pkg);
+    if(api.config.redis.pkg === 'fakeredis'){
       api.log('running with fakeredis', 'warning');
       redisPackage.fast = true;
     }
-      
+
     api.redis.initialize = function(callback){
-      if(api.config.redis.package === 'fakeredis'){
+      if(api.config.redis.pkg === 'fakeredis'){
         api.redis.client     = redisPackage.createClient(String(api.config.redis.host));
         api.redis.subscriber = redisPackage.createClient(String(api.config.redis.host));
       }else{
         api.redis.client     = redisPackage.createClient(api.config.redis.port, api.config.redis.host, api.config.redis.options);
         api.redis.subscriber = redisPackage.createClient(api.config.redis.port, api.config.redis.host, api.config.redis.options);
       }
-      
+
       api.redis.client.on('error', function(err){
         api.log('Redis Error (client): ' + err, 'emerg');
       });
@@ -55,9 +55,9 @@ module.exports = {
         if(api.config.redis.database){ api.redis.client.select(api.config.redis.database); }
         api.log('connected to redis (client)', 'debug');
         api.redis.status.client = true;
-        if(api.redis.status.client === true && api.redis.status.subscriber === true && api.redis.status.calledback === false){ 
+        if(api.redis.status.client === true && api.redis.status.subscriber === true && api.redis.status.calledback === false){
           api.redis.status.calledback = true;
-          callback(); 
+          callback();
         }
       });
 
@@ -71,7 +71,7 @@ module.exports = {
         }
       });
 
-      if(api.config.redis.package === 'fakeredis'){
+      if(api.config.redis.pkg === 'fakeredis'){
         api.redis.status.client = true;
         api.redis.status.subscriber = true;
         process.nextTick(function(){
@@ -200,7 +200,7 @@ module.exports = {
       delete api.redis.clusterCallbaks[i];
     }
     api.redis.doCluster('api.log', ['actionhero member ' + api.id + ' has left the cluster'], null, null);
-    
+
     process.nextTick(function(){
       api.redis.subscriber.unsubscribe();
       next();

--- a/servers/web.js
+++ b/servers/web.js
@@ -80,7 +80,7 @@ var initialize = function(api, options, next){
     if(connection.rawConnection.method !== 'HEAD'){
       stringResponse = String(message);
     }
-    
+
     cleanHeaders(connection);
     var headers = connection.rawConnection.responseHeaders;
     var responseHttpCode = parseInt(connection.rawConnection.responseHttpCode);
@@ -143,8 +143,8 @@ var initialize = function(api, options, next){
       }
     }
 
-    connection.rawConnection.res.on('end', function(){ 
-      connection.destroy(); 
+    connection.rawConnection.res.on('end', function(){
+      connection.destroy();
     });
 
     if(fileStream){
@@ -511,7 +511,7 @@ var initialize = function(api, options, next){
 
   var chmodSocket = function(bindIP, port){
     if(!options.bindIP && options.port.indexOf('/') >= 0){
-      fs.chmodSync(port, 0777);
+      fs.chmodSync(port, 0o777);
     }
   }
 


### PR DESCRIPTION
This pull request fixed the error when using babel-node to load the actionhero:  
    - package is a reserved keyword  => pkg
    - 0777 is not a valid octal number => 0o777

Sorry the diff might looks a lot of lines changed, but actually it is my vim editor changed the lf of the original file. I would like to suggest you consider using .editconfig.