### PR TITLE
when manually reconnecting to ws, destroy and create a new primus transport

### DIFF
--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -44,6 +44,7 @@ ActionheroClient.prototype.connect = function(callback){
     self.client.end();
     self.client.removeAllListeners();
     delete self.client;
+    self.client = Primus.connect(self.options.url, self.options);
   }
   if(self.client && self.externalClient === true){
     self.client.end();

--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -14,6 +14,7 @@ var ActionheroClient = function(options, client){
   }
 
   if(client){
+    self.externalClient = true;
     self.client = client;
   }
 }
@@ -37,12 +38,18 @@ ActionheroClient.prototype.defaults = function(){
 ActionheroClient.prototype.connect = function(callback){
   var self = this;
   self.messageCount = 0;
-  
-  if(!self.client){
-    self.client = Primus.connect(self.options.url, self.options);
-  }else{
+
+
+  if(self.client && self.externalClient !== true){
+    self.client.end();
+    self.client.removeAllListeners();
+    delete self.client;
+  }
+  if(self.client && self.externalClient === true){
     self.client.end();
     self.client.open();
+  }else{
+    self.client = Primus.connect(self.options.url, self.options);
   }
 
   self.client.on('open', function(){


### PR DESCRIPTION
Rather than reuse an existing primus transport, we should create a new one.  This will help solve double-callbacks and double-emits which would otherwise be confusing