### PR TITLE
Change node-uuid to a relative dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ioredis": "1.10.0",
     "mime": "1.3.4",
     "node-resque": "1.1.2",
-    "node-uuid": "1.4.4",
+    "node-uuid": "^1.4.4",
     "optimist": "0.6.1",
     "primus": "4.0.1",
     "uglify-js": "2.6.0",


### PR DESCRIPTION
node-uuid 1.4.6 just came out and looks like they nuked 1.4.4. Needs a relative semver rather than a hard-coded one.

Probably true for the others as well...