### PR TITLE
Update requirements to compatible-with

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,20 +30,20 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "async": "1.5.0",
-    "browser_fingerprint": "0.0.6",
-    "fakeredis": "0.3.4",
-    "formidable": "1.0.17",
-    "grunt": "0.4.5",
-    "ioredis": "1.10.0",
-    "mime": "1.3.4",
-    "node-resque": "1.1.2",
+    "async": "^1.5.0",
+    "browser_fingerprint": "^0.0.6",
+    "fakeredis": "^0.3.4",
+    "formidable": "^1.0.17",
+    "grunt": "^0.4.5",
+    "ioredis": "^1.10.0",
+    "mime": "^1.3.4",
+    "node-resque": "^1.1.2",
     "node-uuid": "^1.4.4",
-    "optimist": "0.6.1",
-    "primus": "4.0.1",
-    "uglify-js": "2.6.0",
-    "winston": "1.1.1",
-    "ws": "0.8.0"
+    "optimist": "^0.6.1",
+    "primus": "^4.0.1",
+    "uglify-js": "^2.6.0",
+    "winston": "^1.1.1",
+    "ws": "^0.8.0"
   },
   "devDependencies": {
     "mocha": "2.3.3",


### PR DESCRIPTION
This changes the package requirements to compatible-with deps instead of hard-coded version numbers. Hopefully this will help prevent immediate failures if packages get unpublished in the future, like node-uuid 1.4.3 did.
