### PR TITLE
Fix broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@
 [![Coverage Status](https://coveralls.io/repos/evantahler/actionhero/badge.svg?branch=master)](https://coveralls.io/r/evantahler/actionhero?branch=master)
 
 ## Who is the actionhero?
-actionhero.js is a multi-transport API Server with integrated cluster capabilities and delayed tasks. The goal of actionhero is to create an easy-to-use toolkit for making **reusable** & **scalable** APIs.  Clients connected to an actionhero server can [**consume the api**](http://actionherojs.com/docs/core/actions.html), [**consume static content**](http://actionherojs.com/docs/core/file-server.html), and [**communicate with each other**](http://actionherojs.com/docs/core/chat.html).  actionhero is cluster-ready, with built in support for background tasks, 0-downtime deploys, and more.
+actionhero.js is a multi-transport API Server with integrated cluster capabilities and delayed tasks. The goal of actionhero is to create an easy-to-use toolkit for making **reusable** & **scalable** APIs.  Clients connected to an actionhero server can [**consume the api**](http://www.actionherojs.com/docs/#actions), [**consume static content**](http://www.actionherojs.com/docs/#file-server), and [**communicate with each other**](http://www.actionherojs.com/docs/#chat).  actionhero is cluster-ready, with built in support for background tasks, 0-downtime deploys, and more.
 
 Currently actionhero supports:
 
-- [Web Clients](http://actionherojs.com/docs/servers/web.html): HTTP, HTTPS
-- [Socket Clients](http://actionherojs.com/docs/servers/socket.html): TCP (telnet), TLS
-- [Web Socket Clients](http://actionherojs.com/docs/servers/websocket.html): HTTP, HTTPS
+- [Web Clients](http://www.actionherojs.com/docs/#web-server): HTTP, HTTPS
+- [Socket Clients](http://www.actionherojs.com/docs/#socket-server): TCP (telnet), TLS
+- [Web Socket Clients](http://www.actionherojs.com/docs/#websocket-server): HTTP, HTTPS
 
-[You can also make your own servers and transports.](http://actionherojs.com/docs/core/servers.html)
+[You can also make your own servers and transports.](http://www.actionherojs.com/docs/#servers)
 
 ## Quick Start
 ```bash
@@ -38,9 +38,9 @@ Or spawn a web API server now:
 
 ## Want more?
 
-- [Getting Started](http://actionherojs.com/docs/ops/getting-started.html)
-- [Running actionhero](http://actionherojs.com/docs/ops/running-actionhero.html)
-- [Read the documentation](http://actionherojs.com/docs)
+- [Getting Started](http://www.actionherojs.com/docs/#getting-started)
+- [Running actionhero](http://www.actionherojs.com/docs/#running-actionhero)
+- [Read the documentation](http://www.actionherojs.com/docs)
 - [View the release history](https://github.com/evantahler/actionhero/releases/)
 
 ## Who?


### PR DESCRIPTION
I've updated the README so that links to the documentation point at the new Slate-based site.