### PR TITLE
Winston++

### DIFF
--- a/actionhero.js
+++ b/actionhero.js
@@ -104,9 +104,9 @@ actionhero.prototype.initialize = function(params, callback){
           });
 
           if(typeof self.initializers[initializer].initialize === 'function'){
-            if(typeof self.api.log === 'function'){ self.api.log('loading initializer: ' + initializer, 'trace', file); }
+            if(typeof self.api.log === 'function'){ self.api.log('loading initializer: ' + initializer, 'debug', file); }
             self.initializers[initializer].initialize(self.api, function(err){
-              try{ self.api.log('loaded initializer: ' + initializer, 'trace', file); }catch(e){ }
+              try{ self.api.log('loaded initializer: ' + initializer, 'debug', file); }catch(e){ }
               next(err);
             });
           }else{

--- a/bin/actionhero
+++ b/bin/actionhero
@@ -12,18 +12,6 @@ var binary = {};
 // logger //
 ////////////
 
-// TODO We need to manually make these levels until winston switches the order back
-binary.logLevels = {
-  emerg: 7,
-  alert: 6,
-  crit: 5,
-  error: 4,
-  warning: 3,
-  notice: 2,
-  info: 1,
-  debug: 0
-}
-
 var transports = []
 if(cluster.isMaster){
   transports.push(
@@ -35,7 +23,7 @@ if(cluster.isMaster){
 }
 
 binary.logger = new (winston.Logger)({
-  levels: binary.logLevels,
+  levels: winston.config.syslog.levels,
   transports: transports
 });
 

--- a/config/logger.js
+++ b/config/logger.js
@@ -35,6 +35,12 @@ exports.default = {
     // the maximum length of param to log (we will truncate)
     logger.maxLogStringLength = 100;
 
+    // you can optionally set custom log levels 
+    // logger.levels = {good: 0, bad: 1};
+
+    // you can optionally set custom log colors 
+    // logger.colors = {good: 'blue', bad: 'red'};
+    
     return logger;
   }
 }

--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -14,36 +14,16 @@ module.exports = {
       }
     }
 
-    api.logger = new (winston.Logger)({
-      // TODO We need to manually make these levels until winston switches the order back
-      levels: {
-        emerg: 8,
-        alert: 7,
-        crit: 6,
-        error: 5,
-        warning: 4,
-        notice: 3,
-        info: 2,
-        debug: 1,
-        trace: 0
-      },
-      colors: {
-        trace: 'magenta',
-        input: 'grey',
-        verbose: 'cyan',
-        prompt: 'grey',
-        debug: 'blue',
-        info: 'green',
-        data: 'grey',
-        help: 'cyan',
-        warn: 'yellow',
-        error: 'red'
-      },
-      transports: transports
-    });
+    api.logger = new (winston.Logger)({ transports: transports });
 
     if(api.config.logger.levels){
+      api.logger.setLevels(api.config.logger.levels);
+    }else{
       api.logger.setLevels(winston.config.syslog.levels);
+    }
+
+    if(api.config.logger.colors){
+      winston.addColors(api.config.logger.colors);
     }
 
     api.log = function(message, severity){
@@ -58,7 +38,7 @@ module.exports = {
     for(i in api.logger.levels){ logLevels.push(i) }
 
     api.log('*** starting actionhero ***', 'notice')
-    api.log('Logger loaded.  Possible levels include: ', 'trace', logLevels);
+    api.log('Logger loaded.  Possible levels include: ', 'debug', logLevels);
 
     next();
 

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -32,7 +32,7 @@ module.exports = {
           self.scheduler.connect(function(){
             self.scheduler.on('start',             function(){               api.log('resque scheduler started', 'info') })
             self.scheduler.on('end',               function(){               api.log('resque scheduler ended', 'info') })
-            self.scheduler.on('poll',              function(){               api.log('resque scheduler polling', 'trace') })
+            self.scheduler.on('poll',              function(){               api.log('resque scheduler polling', 'debug') })
             self.scheduler.on('working_timestamp', function(timestamp){      api.log('resque scheduler working timestamp ' + timestamp, 'debug') })
             self.scheduler.on('transferred_job',   function(timestamp, job){ api.log('resque scheduler enqueuing job ' + timestamp, 'debug', job) })
 
@@ -72,21 +72,21 @@ module.exports = {
         }, api.tasks.jobs);
 
         // normal worker emitters
-        self.multiWorker.on('start',             function(workerId){                      api.log('worker: started', (self.verbose) ? 'info':'trace', {workerId: workerId}                                                   ); })
-        self.multiWorker.on('end',               function(workerId){                      api.log('worker: ended', (self.verbose) ? 'info':'trace',   {workerId: workerId}                                                   ); })
-        self.multiWorker.on('cleaning_worker',   function(workerId, worker, pid){         api.log('worker: cleaning old worker ' + worker + '(' + pid + ')', (self.verbose) ? 'info':'trace'                                 ); })
-        self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, 'trace',       {workerId: workerId}                                                            ); })
+        self.multiWorker.on('start',             function(workerId){                      api.log('worker: started', (self.verbose) ? 'info':'debug', {workerId: workerId}                                                   ); })
+        self.multiWorker.on('end',               function(workerId){                      api.log('worker: ended', (self.verbose) ? 'info':'debug',   {workerId: workerId}                                                   ); })
+        self.multiWorker.on('cleaning_worker',   function(workerId, worker, pid){         api.log('worker: cleaning old worker ' + worker + '(' + pid + ')', (self.verbose) ? 'info':'debug'                                 ); })
+        self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, 'debug',       {workerId: workerId}                                                            ); })
         self.multiWorker.on('job',               function(workerId, queue, job){          api.log('worker: working job ' + queue, 'debug',   {workerId: workerId, job: {class: job.class, queue: job.queue}}                 ); })
         self.multiWorker.on('reEnqueue',         function(workerId, queue, job, plugin){  api.log('worker: reEnqueue job', 'debug',          {workerId: workerId, plugin: plugin, job: {class: job.class, queue: job.queue}} ); })
         self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, 'info',    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
-        self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', 'trace', {workerId: workerId}                                                                            ); })
+        self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', 'debug', {workerId: workerId}                                                                            ); })
 
         self.multiWorker.on('failure',           function(workerId, queue, job, failure){ api.exceptionHandlers.task(failure, queue, job); })
         self.multiWorker.on('error',             function(workerId, queue, job, error){   api.exceptionHandlers.task(error, queue, job);   })
         
         // multiWorker emitters
         self.multiWorker.on('internalError',     function(error){                         api.log(error, 'error'); })
-        self.multiWorker.on('multiWorkerAction', function(verb, delay){                   api.log('*** checked for worker status: ' + verb + ' (event loop delay: ' + delay + 'ms)', 'trace'); })
+        self.multiWorker.on('multiWorkerAction', function(verb, delay){                   api.log('*** checked for worker status: ' + verb + ' (event loop delay: ' + delay + 'ms)', 'debug'); })
         
         if(api.config.tasks.minTaskProcessors > 0){
           self.multiWorker.start(function(){

--- a/initializers/routes.js
+++ b/initializers/routes.js
@@ -112,7 +112,7 @@ module.exports = {
       }
 
       api.params.postVariables = api.utils.arrayUniqueify(api.params.postVariables)
-      api.log(counter + ' routes loaded from ' + api.routes.routesFile, 'trace');
+      api.log(counter + ' routes loaded from ' + api.routes.routesFile, 'debug');
 
       if(api.config.servers.web && api.config.servers.web.simpleRouting === true){
         var simplePaths = [];
@@ -124,7 +124,7 @@ module.exports = {
             api.routes.registerRoute(verb, '/' + action, action);
           }
         }
-        api.log(simplePaths.length + ' simple routes loaded from action names', 'trace');
+        api.log(simplePaths.length + ' simple routes loaded from action names', 'debug');
 
         api.log('routes:', 'debug', api.routes.routes);
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "browser_fingerprint": "^0.0.6",
-    "fakeredis": "^0.3.4",
+    "fakeredis": "^1.0.0",
     "formidable": "^1.0.17",
     "grunt": "^0.4.5",
     "ioredis": "^1.10.0",
@@ -42,15 +42,15 @@
     "optimist": "^0.6.1",
     "primus": "^4.0.1",
     "uglify-js": "^2.6.0",
-    "winston": "^1.1.1",
+    "winston": "^2.0.0",
     "ws": "^0.8.0"
   },
   "devDependencies": {
-    "mocha": "2.3.3",
-    "should": "7.1.1",
-    "request": "2.65.0",
-    "coveralls": "2.11.4",
-    "istanbul": "0.4.0"
+    "mocha": "^2.3.3",
+    "should": "^7.1.1",
+    "request": "^2.65.0",
+    "coveralls": "^2.11.4",
+    "istanbul": "^0.4.0"
   },
   "optionalDependencies": {},
   "bin": {

--- a/site/source/includes/docs/core/logging.md
+++ b/site/source/includes/docs/core/logging.md
@@ -54,6 +54,8 @@ Note that you can set a `level` which indicates which level (and those above it)
 - 6=alert
 - 7=emerg
 
+You can customize these via `api.config.logger.levels` and `api.config.logger.colors`.  See [Winston's documenation for more information](https://github.com/winstonjs/winston#using-custom-logging-levels)
+
 For example, if you set the logger's level to "notice", you would also see "crit" messages, but not "debug" messages.
 
 To invoke the logger from your code, use:


### PR DESCRIPTION
Update Winston to the latest version.

- remove the `trace` log level to be inline with the normal node logging RFC.  See https://github.com/winstonjs/winston#logging for more information
- You can customize these via `api.config.logger.levels` and `api.config.logger.colors`.  See [Winston's documenation for more information](https://github.com/winstonjs/winston#using-custom-logging-levels)