### PR TITLE
Implements task logging verbosity configuration options.

### DIFF
--- a/config/tasks.js
+++ b/config/tasks.js
@@ -5,13 +5,18 @@ exports.default = {
       scheduler: false,
       // what queues should the taskProcessors work?
       queues: ['*'],
-      // Verbosity of task scheduler
-      verbose: true,
       // Logging levels of tasks
       taskLogging : {
         start : 'info',
+        end : 'info',
         success: 'info',
         failure: 'error',
+        cleaning_worker : 'info',
+        poll : 'debug',
+        job : 'debug',
+        enqueue: 'debug',
+        reEnqueue: 'debug',
+        pause: 'debug',
       },
       // how long to sleep between jobs / scheduler checks
       timeout: 5000,

--- a/config/tasks.js
+++ b/config/tasks.js
@@ -5,8 +5,14 @@ exports.default = {
       scheduler: false,
       // what queues should the taskProcessors work?
       queues: ['*'],
-      // Verbosity of task logging
+      // Verbosity of task scheduler
       verbose: true,
+      // Logging levels of tasks
+      taskLogging : {
+        start : 'info',
+        success: 'info',
+        failure: 'error',
+      },
       // how long to sleep between jobs / scheduler checks
       timeout: 5000,
       // at minimum, how many parallel taskProcessors should this node spawn?
@@ -21,7 +27,7 @@ exports.default = {
       // When we kill off a taskProcessor, should we disconnect that local redis connection?
       toDisconnectProcessors: true,
       // What redis server should we connect to for tasks / delayed jobs?
-      redis: api.config.redis
+      redis: api.config.redis,
     }
   }
 }

--- a/config/tasks.js
+++ b/config/tasks.js
@@ -5,18 +5,28 @@ exports.default = {
       scheduler: false,
       // what queues should the taskProcessors work?
       queues: ['*'],
-      // Logging levels of tasks
-      taskLogging : {
-        start : 'info',
-        end : 'info',
-        success: 'info',
-        failure: 'error',
+      // Logging levels of task workers
+      workerLogging : {
+        failure   : 'error', // task failure
+        success   : 'info',  // task success 
+        start     : 'info',
+        end       : 'info',
         cleaning_worker : 'info',
-        poll : 'debug',
-        job : 'debug',
-        enqueue: 'debug',
-        reEnqueue: 'debug',
-        pause: 'debug',
+        poll      : 'debug',
+        job       : 'debug',
+        pause     : 'debug',
+        internalError : 'error',
+        multiWorkerAction : 'debug'
+      },
+      // Logging levels of the task scheduler
+      schedulerLogging : {
+        start     : 'info',
+        end       : 'info',
+        poll      : 'debug',
+        enqueue   : 'debug',
+        reEnqueue : 'debug',
+        working_timestamp : 'debug',
+        transferred_job   : 'debug'
       },
       // how long to sleep between jobs / scheduler checks
       timeout: 5000,

--- a/initializers/exceptions.js
+++ b/initializers/exceptions.js
@@ -98,7 +98,7 @@ module.exports = {
         simpleName = err.message;
       }
       var name = 'task:' + simpleName;
-      api.exceptionHandlers.report(err, 'task', name, {task: task, queue: queue, workerId: workerId}, 'error');
+      api.exceptionHandlers.report(err, 'task', name, {task: task, queue: queue, workerId: workerId}, api.config.tasks.verbose ? 'info' : api.config.tasks.taskLogging.success);
     };
     
     next();

--- a/initializers/exceptions.js
+++ b/initializers/exceptions.js
@@ -98,7 +98,7 @@ module.exports = {
         simpleName = err.message;
       }
       var name = 'task:' + simpleName;
-      api.exceptionHandlers.report(err, 'task', name, {task: task, queue: queue, workerId: workerId}, api.config.tasks.verbose ? 'info' : api.config.tasks.taskLogging.success);
+      api.exceptionHandlers.report(err, 'task', name, {task: task, queue: queue, workerId: workerId}, api.config.tasks.verbose ? 'info' : api.config.tasks.taskLogging.failure);
     };
     
     next();

--- a/initializers/exceptions.js
+++ b/initializers/exceptions.js
@@ -98,7 +98,7 @@ module.exports = {
         simpleName = err.message;
       }
       var name = 'task:' + simpleName;
-      api.exceptionHandlers.report(err, 'task', name, {task: task, queue: queue, workerId: workerId}, api.config.tasks.verbose ? 'info' : api.config.tasks.taskLogging.failure);
+      api.exceptionHandlers.report(err, 'task', name, {task: task, queue: queue, workerId: workerId}, api.config.tasks.workerLogging.failure);
     };
     
     next();

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -58,7 +58,6 @@ module.exports = {
 
       startMultiWorker: function(callback){
         var self = this;
-        self.verbose = api.config.tasks.verbose;
         self.taskLogging = api.config.tasks.taskLogging;
         
         self.multiWorker = new NR.multiWorker({
@@ -73,14 +72,14 @@ module.exports = {
         }, api.tasks.jobs);
 
         // normal worker emitters
-        self.multiWorker.on('start',             function(workerId){                      api.log('worker: started', (self.verbose) ? 'info':'debug', {workerId: workerId}                                                   ); })
-        self.multiWorker.on('end',               function(workerId){                      api.log('worker: ended', (self.verbose) ? 'info':'debug',   {workerId: workerId}                                                   ); })
-        self.multiWorker.on('cleaning_worker',   function(workerId, worker, pid){         api.log('worker: cleaning old worker ' + worker + '(' + pid + ')', (self.verbose) ? 'info':'debug'                                 ); })
-        self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, 'debug',       {workerId: workerId}                                                            ); })
-        self.multiWorker.on('job',               function(workerId, queue, job){          api.log('worker: working job ' + queue, 'debug',   {workerId: workerId, job: {class: job.class, queue: job.queue}}                 ); })
-        self.multiWorker.on('reEnqueue',         function(workerId, queue, job, plugin){  api.log('worker: reEnqueue job', 'debug',          {workerId: workerId, plugin: plugin, job: {class: job.class, queue: job.queue}} ); })
-        self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, self.verbose ? 'info' : self.taskLogging.success,    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
-        self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', 'debug', {workerId: workerId}                                                                            ); })
+        self.multiWorker.on('start',             function(workerId){                      api.log('worker: started', self.taskLogging.start, {workerId: workerId}                                                   ); })
+        self.multiWorker.on('end',               function(workerId){                      api.log('worker: ended', self.taskLogging.end,   {workerId: workerId}                                                   ); })
+        self.multiWorker.on('cleaning_worker',   function(workerId, worker, pid){         api.log('worker: cleaning old worker ' + worker + '(' + pid + ')', self.taskLogging.cleaning_worker                                 ); })
+        self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, self.taskLogging.poll,       {workerId: workerId}                                                            ); })
+        self.multiWorker.on('job',               function(workerId, queue, job){          api.log('worker: working job ' + queue, self.taskLogging.job,   {workerId: workerId, job: {class: job.class, queue: job.queue}}                 ); })
+        self.multiWorker.on('reEnqueue',         function(workerId, queue, job, plugin){  api.log('worker: reEnqueue job', self.taskLogging.reEnqueue,          {workerId: workerId, plugin: plugin, job: {class: job.class, queue: job.queue}} ); })
+        self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, self.taskLogging.success,    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
+        self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', self.taskLogging.pause, {workerId: workerId}                                                                            ); })
 
         self.multiWorker.on('failure',           function(workerId, queue, job, failure){ api.exceptionHandlers.task(failure, queue, job); })
         self.multiWorker.on('error',             function(workerId, queue, job, error){   api.exceptionHandlers.task(error, queue, job);   })

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -25,16 +25,17 @@ module.exports = {
       startScheduler: function(callback){
         var self = this;
         if(api.config.tasks.scheduler === true){
+          self.schedulerLogging = api.config.tasks.schedulerLogging;
           self.scheduler = new NR.scheduler({connection: self.connectionDetails, timeout: api.config.tasks.timeout});
           self.scheduler.on('error', function(error){
             api.log(error, 'error', '[api.resque.scheduler]')
           });
           self.scheduler.connect(function(){
-            self.scheduler.on('start',             function(){               api.log('resque scheduler started', 'info') })
-            self.scheduler.on('end',               function(){               api.log('resque scheduler ended', 'info') })
-            self.scheduler.on('poll',              function(){               api.log('resque scheduler polling', 'debug') })
-            self.scheduler.on('working_timestamp', function(timestamp){      api.log('resque scheduler working timestamp ' + timestamp, 'debug') })
-            self.scheduler.on('transferred_job',   function(timestamp, job){ api.log('resque scheduler enqueuing job ' + timestamp, 'debug', job) })
+            self.scheduler.on('start',             function(){               api.log('resque scheduler started', self.schedulerLogging.start) })
+            self.scheduler.on('end',               function(){               api.log('resque scheduler ended', self.schedulerLogging.end) })
+            self.scheduler.on('poll',              function(){               api.log('resque scheduler polling', self.schedulerLogging.poll) })
+            self.scheduler.on('working_timestamp', function(timestamp){      api.log('resque scheduler working timestamp ' + timestamp, self.schedulerLogging.working_timestamp) })
+            self.scheduler.on('transferred_job',   function(timestamp, job){ api.log('resque scheduler enqueuing job ' + timestamp, self.schedulerLogging.transferred_job, job) })
 
             self.scheduler.start();
             callback();
@@ -58,7 +59,8 @@ module.exports = {
 
       startMultiWorker: function(callback){
         var self = this;
-        self.taskLogging = api.config.tasks.taskLogging;
+        self.workerLogging = api.config.tasks.workerLogging;
+        self.schedulerLogging = api.config.tasks.schedulerLogging;
         
         self.multiWorker = new NR.multiWorker({
           connection:             api.resque.connectionDetails,
@@ -72,21 +74,21 @@ module.exports = {
         }, api.tasks.jobs);
 
         // normal worker emitters
-        self.multiWorker.on('start',             function(workerId){                      api.log('worker: started', self.taskLogging.start, {workerId: workerId}                                                   ); })
-        self.multiWorker.on('end',               function(workerId){                      api.log('worker: ended', self.taskLogging.end,   {workerId: workerId}                                                   ); })
-        self.multiWorker.on('cleaning_worker',   function(workerId, worker, pid){         api.log('worker: cleaning old worker ' + worker + '(' + pid + ')', self.taskLogging.cleaning_worker                                 ); })
-        self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, self.taskLogging.poll,       {workerId: workerId}                                                            ); })
-        self.multiWorker.on('job',               function(workerId, queue, job){          api.log('worker: working job ' + queue, self.taskLogging.job,   {workerId: workerId, job: {class: job.class, queue: job.queue}}                 ); })
-        self.multiWorker.on('reEnqueue',         function(workerId, queue, job, plugin){  api.log('worker: reEnqueue job', self.taskLogging.reEnqueue,          {workerId: workerId, plugin: plugin, job: {class: job.class, queue: job.queue}} ); })
-        self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, self.taskLogging.success,    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
-        self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', self.taskLogging.pause, {workerId: workerId}                                                                            ); })
+        self.multiWorker.on('start',             function(workerId){                      api.log('worker: started', self.workerLogging.start, {workerId: workerId}                                                   ); })
+        self.multiWorker.on('end',               function(workerId){                      api.log('worker: ended', self.workerLogging.end,   {workerId: workerId}                                                   ); })
+        self.multiWorker.on('cleaning_worker',   function(workerId, worker, pid){         api.log('worker: cleaning old worker ' + worker + '(' + pid + ')', self.workerLogging.cleaning_worker                                 ); })
+        self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, self.workerLogging.poll,       {workerId: workerId}                                                            ); })
+        self.multiWorker.on('job',               function(workerId, queue, job){          api.log('worker: working job ' + queue, self.workerLogging.job,   {workerId: workerId, job: {class: job.class, queue: job.queue}}                 ); })
+        self.multiWorker.on('reEnqueue',         function(workerId, queue, job, plugin){  api.log('worker: reEnqueue job', self.workerLogging.reEnqueue,          {workerId: workerId, plugin: plugin, job: {class: job.class, queue: job.queue}} ); })
+        self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, self.workerLogging.success,    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
+        self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', self.workerLogging.pause, {workerId: workerId}                                                                            ); })
 
         self.multiWorker.on('failure',           function(workerId, queue, job, failure){ api.exceptionHandlers.task(failure, queue, job); })
         self.multiWorker.on('error',             function(workerId, queue, job, error){   api.exceptionHandlers.task(error, queue, job);   })
         
         // multiWorker emitters
-        self.multiWorker.on('internalError',     function(error){                         api.log(error, 'error'); })
-        self.multiWorker.on('multiWorkerAction', function(verb, delay){                   api.log('*** checked for worker status: ' + verb + ' (event loop delay: ' + delay + 'ms)', 'debug'); })
+        self.multiWorker.on('internalError',     function(error){                         api.log(error, self.workerLogging.internalError); })
+        self.multiWorker.on('multiWorkerAction', function(verb, delay){                   api.log('*** checked for worker status: ' + verb + ' (event loop delay: ' + delay + 'ms)', self.workerLogging.multiWorkerAction); })
         
         if(api.config.tasks.minTaskProcessors > 0){
           self.multiWorker.start(function(){

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -58,7 +58,8 @@ module.exports = {
 
       startMultiWorker: function(callback){
         var self = this;
-    		self.verbose = api.config.tasks.verbose;
+        self.verbose = api.config.tasks.verbose;
+        self.taskLogging = api.config.tasks.taskLogging;
         
         self.multiWorker = new NR.multiWorker({
           connection:             api.resque.connectionDetails,
@@ -78,7 +79,7 @@ module.exports = {
         self.multiWorker.on('poll',              function(workerId, queue){               api.log('worker: polling ' + queue, 'debug',       {workerId: workerId}                                                            ); })
         self.multiWorker.on('job',               function(workerId, queue, job){          api.log('worker: working job ' + queue, 'debug',   {workerId: workerId, job: {class: job.class, queue: job.queue}}                 ); })
         self.multiWorker.on('reEnqueue',         function(workerId, queue, job, plugin){  api.log('worker: reEnqueue job', 'debug',          {workerId: workerId, plugin: plugin, job: {class: job.class, queue: job.queue}} ); })
-        self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, 'info',    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
+        self.multiWorker.on('success',           function(workerId, queue, job, result){  api.log('worker: job success ' + queue, self.verbose ? 'info' : self.taskLogging.success,    {workerId: workerId, job: {class: job.class, queue: job.queue}, result: result} ); })
         self.multiWorker.on('pause',             function(workerId){                      api.log('worker: paused', 'debug', {workerId: workerId}                                                                            ); })
 
         self.multiWorker.on('failure',           function(workerId, queue, job, failure){ api.exceptionHandlers.task(failure, queue, job); })

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -175,7 +175,7 @@ module.exports = {
           self.del(task.queue, taskName, {}, function(){
             self.delDelayed(task.queue, taskName, {}, function(){
               self.enqueueIn(task.frequency, taskName, function(){
-                api.log('re-enqueued recurrent job ' + taskName, api.tasks.verbose ? 'info' : api.config.tasks.taskLogging.enqueue);
+                api.log('re-enqueued recurrent job ' + taskName, api.config.tasks.taskLogging.reEnqueue);
                 callback();
               });
             });
@@ -194,7 +194,7 @@ module.exports = {
             (function(taskName){
               self.enqueue(taskName, function(err, toRun){
                 if(toRun === true){ 
-                  api.log('enqueuing periodic task: ' + taskName, api.tasks.verbose ? 'info' : api.config.tasks.taskLogging.enqueue);
+                  api.log('enqueuing periodic task: ' + taskName, api.config.tasks.taskLogging.enqueue);
                   loadedTasks.push(taskName);
                 }
                 started--;

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -175,7 +175,7 @@ module.exports = {
           self.del(task.queue, taskName, {}, function(){
             self.delDelayed(task.queue, taskName, {}, function(){
               self.enqueueIn(task.frequency, taskName, function(){
-                api.log('re-enqueued recurrent job ' + taskName, 'debug');
+                api.log('re-enqueued recurrent job ' + taskName, api.tasks.verbose ? 'info' : api.config.tasks.taskLogging.enqueue);
                 callback();
               });
             });
@@ -194,7 +194,7 @@ module.exports = {
             (function(taskName){
               self.enqueue(taskName, function(err, toRun){
                 if(toRun === true){ 
-                  api.log('enqueuing periodic task: ' + taskName, 'info');
+                  api.log('enqueuing periodic task: ' + taskName, api.tasks.verbose ? 'info' : api.config.tasks.taskLogging.enqueue);
                   loadedTasks.push(taskName);
                 }
                 started--;

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -175,7 +175,7 @@ module.exports = {
           self.del(task.queue, taskName, {}, function(){
             self.delDelayed(task.queue, taskName, {}, function(){
               self.enqueueIn(task.frequency, taskName, function(){
-                api.log('re-enqueued recurrent job ' + taskName, api.config.tasks.taskLogging.reEnqueue);
+                api.log('re-enqueued recurrent job ' + taskName, api.config.tasks.schedulerLogging.reEnqueue);
                 callback();
               });
             });
@@ -194,7 +194,7 @@ module.exports = {
             (function(taskName){
               self.enqueue(taskName, function(err, toRun){
                 if(toRun === true){ 
-                  api.log('enqueuing periodic task: ' + taskName, api.config.tasks.taskLogging.enqueue);
+                  api.log('enqueuing periodic task: ' + taskName, api.config.tasks.schedulerLogging.enqueue);
                   loadedTasks.push(taskName);
                 }
                 started--;

--- a/site/source/includes/docs/core/tasks.md
+++ b/site/source/includes/docs/core/tasks.md
@@ -55,7 +55,7 @@ exports.default = {
       scheduler: false,
       // what queues should the TaskProcessors work?
       queues: ['*'],
-      // Verbosity of task scheduler
+      // Verbosity of task scheduler (overrides the below task logging levels when set to true)
       verbose: true,
       // Logging levels of tasks
       taskLogging : {

--- a/site/source/includes/docs/core/tasks.md
+++ b/site/source/includes/docs/core/tasks.md
@@ -55,18 +55,28 @@ exports.default = {
       scheduler: false,
       // what queues should the TaskProcessors work?
       queues: ['*'],
-      // Logging levels of tasks
-      taskLogging : {
-        start : 'info',
-        end : 'info',
-        success: 'info',
-        failure: 'error',
+      // Logging levels of task workers
+      workerLogging : {
+        failure   : 'error', // task failure
+        success   : 'info',  // task success 
+        start     : 'info',
+        end       : 'info',
         cleaning_worker : 'info',
-        poll : 'debug',
-        job : 'debug',
-        enqueue: 'debug',
-        reEnqueue: 'debug',
-        pause: 'debug',
+        poll      : 'debug',
+        job       : 'debug',
+        pause     : 'debug',
+        internalError : 'error',
+        multiWorkerAction : 'debug'
+      },
+      // Logging levels of the task scheduler
+      schedulerLogging : {
+        start     : 'info',
+        end       : 'info',
+        poll      : 'debug',
+        enqueue   : 'debug',
+        reEnqueue : 'debug',
+        working_timestamp : 'debug',
+        transferred_job   : 'debug'
       },
       // how long to sleep between jobs / scheduler checks
       timeout: 5000,

--- a/site/source/includes/docs/core/tasks.md
+++ b/site/source/includes/docs/core/tasks.md
@@ -55,13 +55,18 @@ exports.default = {
       scheduler: false,
       // what queues should the TaskProcessors work?
       queues: ['*'],
-      // Verbosity of task scheduler (overrides the below task logging levels when set to true)
-      verbose: true,
       // Logging levels of tasks
       taskLogging : {
         start : 'info',
+        end : 'info',
         success: 'info',
         failure: 'error',
+        cleaning_worker : 'info',
+        poll : 'debug',
+        job : 'debug',
+        enqueue: 'debug',
+        reEnqueue: 'debug',
+        pause: 'debug',
       },
       // how long to sleep between jobs / scheduler checks
       timeout: 5000,

--- a/site/source/includes/docs/core/tasks.md
+++ b/site/source/includes/docs/core/tasks.md
@@ -55,6 +55,14 @@ exports.default = {
       scheduler: false,
       // what queues should the TaskProcessors work?
       queues: ['*'],
+      // Verbosity of task scheduler
+      verbose: true,
+      // Logging levels of tasks
+      taskLogging : {
+        start : 'info',
+        success: 'info',
+        failure: 'error',
+      },
       // how long to sleep between jobs / scheduler checks
       timeout: 5000,
       // at minimum, how many parallel taskProcessors should this node spawn?


### PR DESCRIPTION
See the config file for the user-facing updates to task logging. The verbose option was left intact for scheduler logging, and is used to override the task verbosity. I did this to keep a single option around for quick debugging but I'm open to tweaking this!

This change is backwards-compatible and transparent to extisting configurations and includes documentation updates (Implements #719)