### PR TITLE
Normalize the logging directory config + error fix

### DIFF
--- a/config/logger.js
+++ b/config/logger.js
@@ -18,10 +18,11 @@ exports.default = {
 
     // file logger
     try{
-      fs.mkdirSync('./log');
+      fs.mkdirSync(api.config.general.paths.log[0]);
     } catch(e) {
       if(e.code !== 'EEXIST'){
-        return next([new Error('Cannot create ./log directory'), e])
+        var message = 'Cannot create the log directory ' + api.config.general.paths.log[0] + ' specified in api.config.general.paths.log'
+        throw new Error(message)
       }
     }
     logger.transports.push(function(api, winston) {


### PR DESCRIPTION
This commit creates the logging directory according to the API config, rather than at the project root. This also means that the created directory matches the one used in line 30 for the Winston transport.

I also replaced the next(err) callback with a thrown error since api.log is not yet defined and config files don't use callbacks.

I ran across this bug while toying around with different config/api.js path configurations for different AH project directory structures.