### PR TITLE
fix symlink creation on windows

### DIFF
--- a/bin/actionhero
+++ b/bin/actionhero
@@ -94,7 +94,7 @@ binary.utils = {
       binary.log(' - symbolic link \'' + destination + '\' already exists, skipping', 'alert');
     } else {
       binary.log(' - creating symbolic link \'' + destination + '\' => \'' + source + '\'');
-      fs.symlinkSync(source, destination);
+      fs.symlinkSync(source, destination, 'dir');
     }
   },
   hashLength: function(obj){


### PR DESCRIPTION
This pull request fixes the symlink creation on windows.

See https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback

fs.symlink(target, path[, type], callback)

The type argument can be set to 'dir', 'file', or 'junction' (default is 'file') and is only available on Windows (ignored on other platforms