### PR TITLE
fix(initializers): paramAdd with no params raises TypeError

### DIFF
--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -197,7 +197,7 @@ module.exports = {
         } else if(verb === 'paramAdd'){
           key = words[0];
           value = words[1];
-          if(words[0].indexOf('=') >= 0){
+          if((words[0]) && (words[0].indexOf('=') >= 0)){
             var parts = words[0].split('=');
             key = parts[0];
             value = parts[1];


### PR DESCRIPTION
Using paramAdd over tcp socket with no arguments throws TypeError

/node_modules/actionhero/initializers/connections.js:200
          if(words[0].indexOf('=') >= 0){
                     ^

TypeError: Cannot read property 'indexOf' of undefined