### PR TITLE
serve static files from linked plugins

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -4,7 +4,7 @@
 
 This folder contains the build files for www.actionherojs.com (which are served by github-pages)
 
-We use [Middleman](https://middlemanapp.com/) to build and compile this site, and host it for free on [Github Pages](http://pages.github.com/). Pages can be written in markdown or HTML, and Jekyll will build the site. 
+We use [Middleman](https://middlemanapp.com/) to build and compile this site, and host it for free on [Github Pages](http://pages.github.com/). Pages can be written in markdown or HTML, and Middleman will build the site. 
 
 There are two main parts of the site (and consequently 2 main layouts): `home` and `docs`.
 

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -575,7 +575,7 @@ describe('Server: Web', function(){
 
       before(function(done){
         fs.createReadStream(source).pipe(fs.createWriteStream('/tmp/testFile.html'));
-        api.config.general.paths.public.push('/tmp');
+        api.staticFile.searchLoactions.push('/tmp');
         process.nextTick(function(){
           done();
         });
@@ -583,7 +583,7 @@ describe('Server: Web', function(){
 
       after(function(done){
         fs.unlink('/tmp/testFile.html');
-        api.config.general.paths.public.pop();
+        api.staticFile.searchLoactions.pop();
         process.nextTick(function(){
           done();
         });


### PR DESCRIPTION
[HOTFIX] - When linking plugins with public directories, their `/public` directories should be sourced by the static file server.  

We should not modify `api.config.general.paths.public` to do this.