### PR TITLE
Package keyword issues

### DIFF
--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -18,7 +18,7 @@ module.exports = {
     };
 
     if(api.config.redis.package && !api.config.redis.pkg) {
-      api.log(`Depreciation warning: New versions of actionhero utilize 'pkg' instead of 'package' for redis! Please update your configuration.`)
+      api.log(`Depreciation warning: New versions of actionhero utilize 'pkg' instead of 'package' for redis! Please update your configuration.`);
       api.config.redis.pkg = api.config.redis.package;
     }
 

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -16,7 +16,7 @@ module.exports = {
       subscribed: false,
       calledback: false,
     };
-
+    api.config.redis.pkg = api.config.redis.pkg || api.config.redis.package;
     var redisPackage = require(api.config.redis.pkg);
     if(api.config.redis.pkg === 'fakeredis'){
       api.log('running with fakeredis', 'warning');


### PR DESCRIPTION
Older actionhero installs used redis.package instead of redis.pkg (12.2.0 at least) so this should ensure backwards compatibility.