### PR TITLE
#772 - Using the `ActionheroClient.prototype.actionWeb` with GET method

### DIFF
--- a/client/actionheroClient.js
+++ b/client/actionheroClient.js
@@ -191,8 +191,16 @@ ActionheroClient.prototype.actionWeb = function(params, callback) {
     }
   };
 
-  var method = params.httpMethod || 'POST';
+  var method = (params.httpMethod || 'POST').toUpperCase();
   var url = this.options.url + this.options.apiPath + '?action=' + params.action;
+
+  if (method === 'GET') {
+    for (var param in params) {
+      if (~['action', 'httpMethod'].indexOf(param)) continue;
+      url += '&' + param + '=' + params[param];
+    }
+  }
+
   xmlhttp.open(method, url, true);
   xmlhttp.setRequestHeader('Content-Type', 'application/json');
   xmlhttp.send(JSON.stringify(params));


### PR DESCRIPTION
Referring to #772, will enable to have the `GET` query params inside the url in case of a client action is called using the actionWeb method

ex:
``` javascript
client.action("myActionName", {httpMethod: 'GET', param1: value1, param2: value2}, function (apiResponse) {
    console.log(apiResponse)
});

// will result to:

{webApiUrl}/api?action=myActionName&param1=value1&param2=value2
```