### PR TITLE
node-resque v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "actionhero",
   "description": "actionhero.js is a multi-transport API Server with integrated cluster capabilities and delayed tasks",
-  "version": "13.1.1",
+  "version": "13.2.0",
   "homepage": "http://www.actionherojs.com",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "ioredis": "^1.10.0",
     "is-running": "^2.0.0",
     "mime": "^1.3.4",
-    "node-resque": "^1.3.0",
+    "node-resque": "^2.0.0",
     "node-uuid": "^1.4.4",
     "optimist": "^0.6.1",
     "primus": "^4.0.1",


### PR DESCRIPTION
From node resque: https://github.com/taskrabbit/node-resque/pull/121

**This is a breaking change**

When comparing this project to ruby resque, we had been using the wrong value (key pointer) in the delayed job queue.  When running this project alongside a ruby scheduler, it was possible for older timestamp key set entries not to be deleted.  This update corrects the difference. 

When upgrading to this new version, it is very likely you will end up with queue artifacts that are not properly deleted, which have the potential to break plugin's behaviors.  This will require manual intervention to remove keys that match `resque:timestamps:*`.  Before upgrading to this version, the safest path forward is to drain all of your queues and schedules first, using the previous version of node-resque. 

---

As far as actionhero is concerned, this issue would only effect you if your application uses scheduler and `api.tasks.enqueueAt` or `api.tasks.enqueueIn` directly.  This is why we have made this a minor version update.