### PR TITLE
Support /public filenames with encoded spaces in URL

### DIFF
--- a/servers/web.js
+++ b/servers/web.js
@@ -447,10 +447,10 @@ var initialize = function(api, options, next){
         connection.params.file = connection.params.file + api.config.general.directoryFileType;
       }
       try {
-        connection.params.file = decodeURIComponent(connection.params.file).replace(/\++/g, ' ');
+        connection.params.file = decodeURIComponent(connection.params.file);
       }
       catch(e) {
-        connection.error = new Error('There was an error decode URI.');
+        connection.error = new Error('There was an error decoding URI: ' + e);
       }
       callback(requestMode);
     }

--- a/servers/web.js
+++ b/servers/web.js
@@ -446,6 +446,12 @@ var initialize = function(api, options, next){
       if(connection.params.file === '' || connection.params.file[connection.params.file.length - 1] === '/'){
         connection.params.file = connection.params.file + api.config.general.directoryFileType;
       }
+      try {
+        connection.params.file = decodeURIComponent(connection.params.file).replace(/\++/g, ' ');
+      }
+      catch(e) {
+        connection.error = new Error('There was an error decode URI.');
+      }
       callback(requestMode);
     }
 

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -909,6 +909,45 @@ describe('Server: Web', function(){
 
     });
 
+    describe('spaces in URL with public files', function() {
+
+      var source = __dirname + '/../../public/logo/sky.jpg'
+
+      before(function(done){
+        fs.createReadStream(source).pipe(fs.createWriteStream('/tmp/sky with space.jpg'));
+        api.staticFile.searchLoactions.push('/tmp');
+        process.nextTick(function(){
+          done();
+        });
+      });
+
+      after(function(done){
+        fs.unlink('/tmp/sky with space.jpg');
+        api.staticFile.searchLoactions.pop();
+        process.nextTick(function(){
+          done();
+        });
+      });
+
+      it('will decode %20 or plus sign to a space so that file system can read', function (done) {
+        request.get(url + '/sky%20with+space.jpg', function (err, response) {
+          response.statusCode.should.equal(200)
+          response.body.should.be.an.instanceOf(Object);
+          response.headers['content-type'].should.equal('image/jpeg');
+          done();
+        });
+      });
+
+      it('will capture bad encoding in URL and return NOT FOUND', function (done) {
+        request.get(url + '/sky%20%with+space.jpg', function (err, response) {
+          response.statusCode.should.equal(404)
+          response.body.should.be.an.instanceOf(String);
+          response.body.should.startWith('That file is not found');
+          done();
+        });
+      });
+
+    })
   });
 
 });

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -930,7 +930,7 @@ describe('Server: Web', function(){
       });
 
       it('will decode %20 or plus sign to a space so that file system can read', function (done) {
-        request.get(url + '/sky%20with+space.jpg', function (err, response) {
+        request.get(url + '/sky%20with%20space.jpg', function (err, response) {
           response.statusCode.should.equal(200)
           response.body.should.be.an.instanceOf(Object);
           response.headers['content-type'].should.equal('image/jpeg');
@@ -939,7 +939,7 @@ describe('Server: Web', function(){
       });
 
       it('will capture bad encoding in URL and return NOT FOUND', function (done) {
-        request.get(url + '/sky%20%with+space.jpg', function (err, response) {
+        request.get(url + '/sky%20%%%%%%%%%%with+space.jpg', function (err, response) {
           response.statusCode.should.equal(404)
           response.body.should.be.an.instanceOf(String);
           response.body.should.startWith('That file is not found');


### PR DESCRIPTION
Support /public filenames with encoded spaces in URL. The URL must be properly encoded, for example, note the %20 and +:

http://localhost:8080/sky%20with+space.jpg
