### PR TITLE
Added "use strict" to templates

### DIFF
--- a/bin/templates/action.js
+++ b/bin/templates/action.js
@@ -1,3 +1,4 @@
+"use strict";
 exports.action = {
   name:                   '%%name%%',
   description:            '%%description%%',

--- a/bin/templates/initializer.js
+++ b/bin/templates/initializer.js
@@ -1,3 +1,4 @@
+"use strict";
 module.exports = {
   loadPriority:  1000,
   startPriority: 1000,

--- a/bin/templates/server.js
+++ b/bin/templates/server.js
@@ -1,3 +1,4 @@
+"use strict";
 var initialize = function(api, options, next){
 
   //////////

--- a/bin/templates/task.js
+++ b/bin/templates/task.js
@@ -1,3 +1,4 @@
+"use strict";
 exports.task = {
   name:          '%%name%%',
   description:   '%%description%%',


### PR DESCRIPTION
Nothing major, but saves a hassle of a step if I want to use ES6 or ES7 features in Actionhero.