### PR TITLE
eslint npm script, instructions, and a single style fix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+bin/templates/
+client/
+public/
+site/
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ too, and here's a list of few select plugins for your convenience:
 - [Sublime Text plugin](https://github.com/roadhump/SublimeLinter-eslint)
 - [generic syntax-checking Vim plugin](https://github.com/scrooloose/syntastic)
 
+It's easy to check that you got it right even without plugin - just run `npm run lint`!
+
 *Person who does not change is a monument of itself*, so, be not afraid of
 improving the ruleset, but do run through the entirety of the codebase to adjust
 for the changes.

--- a/initializers/servers.js
+++ b/initializers/servers.js
@@ -78,7 +78,7 @@ module.exports = {
         }
 
         api.log([message].concat(messageArgs), 'notice');
-        
+
         api.servers.servers[server].start(function(error){
           if(error){ return next(error); }
           process.nextTick(function(){

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "start": "node ./bin/actionhero",
     "site": "cd site && EXECJS_RUNTIME=Node bundle exec middleman",
     "site:publish": "cd site && ./deploy.sh",
-    "postpublish": "npm run-script site:publish"
+    "postpublish": "npm run-script site:publish",
+    "lint": "eslint ."
   }
 }


### PR DESCRIPTION
- now `eslint` dependency makes sense
- it's easy to check style - just run `npm run lint`
- added .eslintignore to not check troublesome scripts (client, templates, site, ...)

A side note - there really was no need for Grunt. Good call removing it.