### PR TITLE
expose matched route to connection

### DIFF
--- a/initializers/routes.js
+++ b/initializers/routes.js
@@ -31,6 +31,7 @@ module.exports = {
                 // malformed URL
               }
             }
+            connection.matchedRoute = route;
             connection.params.action = route.action;
             break;
           }

--- a/site/source/includes/docs/servers/web.md
+++ b/site/source/includes/docs/servers/web.md
@@ -281,6 +281,8 @@ exports.default = function(api) {
 
 This would create both `/api/myAction/old` and `/api/myAction/new`, mapping to apiVersion 1 and 2 respectively.
 
+In your actions and middleware, if a route was matched, you can see the details of the match by inspecting `data.connection.matchedRoute` which will include `path` and `action`.
+
 Finally, you can toggle an option, `matchTrailingPathParts`, which allows the final segment of your route to absorb all trailing path parts in a matched variable.
 
 
@@ -315,7 +317,7 @@ get: [
 ],
 ```
 
-**Note**: In regular expressions used for routing, you cannot use the "/" character.   
+**Note**: In regular expressions used for routing, you cannot use the "/" character.
 
 #### Notes
 
@@ -332,8 +334,6 @@ get: [
   - IE: `{ path:"/game/:id(^[a-z]{0,10}$)", action: "gamehandler" }`
   - be sure to double-escape when needed: `{ path: "/login/:userID(^\\d{3}$)", action: "login" }`
 - The HTTP verbs which you can route against are: `api.routes.verbs = ['head', 'get', 'post', 'put', 'patch', 'delete']`
-
-**example**:
 
 ```javascript
 exports.default = function(api) {

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -664,6 +664,7 @@ describe('Server: Web', function(){
           },
           outputExample: {},
           run:function(api, data, next){
+            data.response.matchedRoute = data.connection.matchedRoute;
             next();
           }
         }
@@ -765,6 +766,15 @@ describe('Server: Web', function(){
       request.get(url + '/api/user/123?action=someFakeAction', function(err, response, body){
         body = JSON.parse(body);
         body.requesterInformation.receivedParams.action.should.equal('user');
+        done();
+      });
+    });
+
+    it('route actions have the matched route availalbe to the action', function(done){
+      request.get(url + '/api/mimeTestAction/thing.json', function(err, response, body){
+        body = JSON.parse(body);
+        body.matchedRoute.path.should.equal('/mimeTestAction/:key');
+        body.matchedRoute.action.should.equal('mimeTestAction');
         done();
       });
     });


### PR DESCRIPTION
now you can check `connection.matchedRoute` to see the details of the route that got the `web` connection to this action... if in case a route was matched.

```js
data.connection.matchedRoute = { 
  path: '/mimeTestAction/:key',
  matchTrailingPathParts: false,
  action: 'mimeTestAction'
 }
```