### PR TITLE
I18n rewrite

### DIFF
--- a/config/errors.js
+++ b/config/errors.js
@@ -79,7 +79,7 @@ exports['default'] = {
       },
 
       dataLengthTooLarge: function(maxLength, receivedLength){
-        return 'data length is too big (' + maxLength + '<' + receivedLength + ')';
+        return api.i18n.localize(['data length is too big (%u received/%u max)', maxLength, receivedLength]);
       },
 
       /////////////////
@@ -127,19 +127,19 @@ exports['default'] = {
       },
 
       connectionRoomHasBeenDeleted: function(room){
-        return 'this room has been deleted';
+        return api.i18n.localize('this room has been deleted');
       },
 
       connectionRoomNotExist: function(room){
-        return 'room does not exist';
+        return api.i18n.localize('room does not exist');
       },
 
       connectionRoomExists: function(room){
-        return 'room exists';
+        return api.i18n.localize('room exists');
       },
 
       connectionRoomRequired: function(room){
-        return 'a room is required';
+        return api.i18n.localize('a room is required');
       },
 
     };

--- a/initializers/cache.js
+++ b/initializers/cache.js
@@ -123,7 +123,7 @@ module.exports = {
         try{ cacheObj = JSON.parse(cacheObj); }catch(e){}
         if(!cacheObj){
           if(typeof callback === 'function'){
-            return callback(new Error('Object not found'), null, null, null, null);
+            return callback(new Error(api.i18n.localize('Object not found')), null, null, null, null);
           }
         }else if(cacheObj.expireTimestamp >= new Date().getTime() || cacheObj.expireTimestamp === null){
           var lastReadAt = cacheObj.readAt;
@@ -140,7 +140,7 @@ module.exports = {
 
           api.cache.checkLock(key, options.retry, function(error, lockOk){
             if(error || lockOk !== true){
-              if(typeof callback === 'function'){ return callback(new Error('Object Locked')); }
+              if(typeof callback === 'function'){ return callback(new Error(api.i18n.localize('Object Locked'))); }
             }else{
               api.redis.client.set(api.cache.redisPrefix + key, JSON.stringify(cacheObj), function(error){
                 if(typeof callback === 'function' && typeof expireTimeSeconds !== 'number'){
@@ -155,7 +155,7 @@ module.exports = {
           });
         }else{
           if(typeof callback === 'function'){
-            return callback(new Error('Object Expired'));
+            return callback(new Error(api.i18n.localize('Object Expired')));
           }
         }
       });
@@ -164,7 +164,7 @@ module.exports = {
     api.cache.destroy = function(key, callback){
       api.cache.checkLock(key, null, function(error, lockOk){
         if(error || lockOk !== true){
-          if(typeof callback === 'function'){ callback(new Error('Object Locked')); }
+          if(typeof callback === 'function'){ callback(new Error(api.i18n.localize('Object Locked'))); }
         }else{
           api.redis.client.del(api.cache.redisPrefix + key, function(error, count){
             if(error){ api.log(error, 'error'); }
@@ -198,7 +198,7 @@ module.exports = {
 
       api.cache.checkLock(key, null, function(error, lockOk){
         if(error || lockOk !== true){
-          if(typeof callback === 'function'){ return callback(new Error('Object Locked')); }
+          if(typeof callback === 'function'){ return callback(new Error(api.i18n.localize('Object Locked'))); }
         }else{
           api.redis.client.set(api.cache.redisPrefix + key, JSON.stringify(cacheObj), function(error){
             if(!error && expireTimeSeconds){

--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -139,8 +139,7 @@ module.exports = {
 
     api.connection.prototype.localize = function(message){
       // this.locale will be sourced automatically
-      if(!Array.isArray(message)){ message = [message]; }
-      return api.i18n.i18n.__.apply(this, message);
+      return api.i18n.localize(message, this);
     };
 
     api.connection.prototype.generateID = function(){

--- a/initializers/i18n.js
+++ b/initializers/i18n.js
@@ -2,7 +2,6 @@
 
 var i18n = require('i18n');
 var path = require('path');
-var extend = require('util')._extend;
 
 module.exports = {
   loadPriority:  1,
@@ -12,7 +11,7 @@ module.exports = {
     i18n.configure(options);
     i18n.setLocale(api.config.i18n.defaultLocale);
 
-    api.i18n = extend({
+    api.i18n = Object.assign({
       // simplistic determination of locale for connection
       determineConnectionLocale: function(connection){
         // perhpas you want to look at the `accept-language` headers from a web requests

--- a/initializers/i18n.js
+++ b/initializers/i18n.js
@@ -19,7 +19,6 @@ module.exports = {
         // perhaps your API can use a certain cookie or URL to determine locale
         return api.config.i18n.defaultLocale;
       },
-
       invokeConnectionLocale: function(connection){
         var cmdParts = api.config.i18n.determineConnectionLocale.split('.');
         var cmd = cmdParts.shift();
@@ -28,7 +27,6 @@ module.exports = {
         var locale = method(connection);
         api.i18n.setLocale(connection, locale);
       },
-
       localize: function(message, options){
         if(!Array.isArray(message)){ message = [message]; }
         if(!options){ options = api.i18n; }

--- a/initializers/i18n.js
+++ b/initializers/i18n.js
@@ -2,13 +2,17 @@
 
 var i18n = require('i18n');
 var path = require('path');
+var extend = require('util')._extend;
 
 module.exports = {
   loadPriority:  1,
   initialize: function(api, next){
-    api.i18n = {
-      // i18n: i18n,
+    var options = api.config.i18n;
+    options.directory = path.normalize(api.config.general.paths.locale[0]);
+    i18n.configure(options);
+    i18n.setLocale(api.config.i18n.defaultLocale);
 
+    api.i18n = extend({
       // simplistic determination of locale for connection
       determineConnectionLocale: function(connection){
         // perhpas you want to look at the `accept-language` headers from a web requests
@@ -22,16 +26,15 @@ module.exports = {
         if(cmd !== 'api'){ throw new Error('cannot operate on a method outside of the api object'); }
         var method = api.utils.stringToHash(cmdParts.join('.'));
         var locale = method(connection);
-        api.i18n.i18n.setLocale(connection, locale);
+        api.i18n.setLocale(connection, locale);
+      },
+
+      localize: function(message, options){
+        if(!Array.isArray(message)){ message = [message]; }
+        if(!options){ options = api.i18n; }
+        return api.i18n.__.apply(options, message);
       }
-    };
-
-    var options = api.config.i18n;
-    options.directory = path.normalize(api.config.general.paths.locale[0]);
-    i18n.configure(options);
-    i18n.setLocale(api.config.i18n.defaultLocale);
-
-    api.i18n.i18n = i18n;
+    }, i18n);
 
     next();
   }

--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -30,8 +30,7 @@ module.exports = {
     }
 
     api.log = function(message, severity, data){
-      if(!Array.isArray(message)){ message = [message]; }
-      var localizedMessage = api.i18n.i18n.__.apply(api.i18n.i18n, message);
+      var localizedMessage = api.i18n.localize(message);
       if(severity === undefined || severity === null || api.logger.levels[severity] === undefined){ severity = 'info'; }
       var args = [severity, localizedMessage];
       if(data !== null && data !== undefined){ args.push(data); }

--- a/site/source/includes/docs/core/localization.md
+++ b/site/source/includes/docs/core/localization.md
@@ -3,7 +3,7 @@
 Starting in Actionhero `v13.0.0`, you can now use the [i18n](https://github.com/mashpie/i18n-node) module to customize all aspects of actionhero.
 
 ## Locale files
-- When running actionhero with `api.config.i18n.updateFiles = true`, you will see actionhero generate a 'locales' folder at the top level of your project which will contain translations of all strings in your project with are passed though the new localization system.  This includes all uses of `connection.localize` and `api.log`.  
+- When running actionhero with `api.config.i18n.updateFiles = true`, you will see actionhero generate a 'locales' folder at the top level of your project which will contain translations of all strings in your project with are passed though the new localization system.  This includes all uses of `api.i18n.localize`, `connection.localize` and `api.log`.  
   - be sure to use sprintf-style string interpolation for variables!
 - From here, it is an easy matter to change the strings, per locale, to how you would like them presented back in your application.  The next time you restart the server, the values you've updated in your locale strings file will be used.
 - disable `api.config.i18n.updateFiles` if you do not want this behavior.
@@ -47,3 +47,9 @@ To tell the i18n to use this method with a new connection, set `api.config.i18n.
   - You might want to log the message `api.log(['The time is %s', new Date()], 'alert')`.  
   - Changing the translation of the string `The time is %s` in your locale files would apply to the logger as well!
   - You can of course continue to log plain strings as we have been with the logger as well.
+
+## Localizing other strings
+- To localize strings that are not used in methods mentioned above you can use `api.i18n.localize(string, options)` or `api.i18n.localize([string-with-interpolation, value], options)`.
+  - Allows you to interpolate a string.
+  - Just as the other localize methods above, the input string will be in your locale files for you to change it anytime you want.
+  - The second `options` optional argument (default value is `api.i18n`) allows you to [configure](https://github.com/mashpie/i18n-node#list-of-all-configuration-options) i18n. Note that you will use this argument only in very few special cases, It is recommended to edit the global `api.config.i18n` settings to suit your localization needs.

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -29,7 +29,7 @@ describe('Core: i18n', function(){
       var options = api.config.i18n;
       options.directory = api.config.general.paths.locale[0];
       options.locales = ['en', 'es'];
-      api.i18n.i18n.configure(options);
+      api.i18n.configure(options);
       done();
     });
   });

--- a/test/servers/socket.js
+++ b/test/servers/socket.js
@@ -240,7 +240,7 @@ describe('Server: Socket', function(){
       }
     };
     makeSocketRequest(client, JSON.stringify(msg), function(response){
-      response.should.containEql({status: 'error', error: 'data length is too big (64<449)'});
+      response.should.containEql({status: 'error', error: 'data length is too big (64 received/449 max)'});
       // Return maxDataLength back to normal
       api.config.servers.socket.maxDataLength = 0;
       done();


### PR DESCRIPTION
No more ugly `api.i18n.i18n...` calls. Added `api.i18n.localize`. 
Also localized some strings in `initializers/cache.js` and `config/errors.js`.

Localizing strings is now really easy. :) I guess documentation has to be changed now.

`api.i18n.localize(message, options)`, first argument is sprintf array it can also accept a string, second argument is optional ( default is api.i18n )