### PR TITLE
Bring your own workers

### DIFF
--- a/config/tasks.js
+++ b/config/tasks.js
@@ -43,6 +43,12 @@ exports['default'] = {
       toDisconnectProcessors: true,
       // What redis server should we connect to for tasks / delayed jobs?
       redis: api.config.redis,
+      // Customize Resque primitives, replace null with required replacement.
+      resque: {
+        queue: api.customResque.queue,
+        multiWorker: null,
+        scheduler: null
+      }
     };
   }
 };

--- a/config/tasks.js
+++ b/config/tasks.js
@@ -44,7 +44,7 @@ exports['default'] = {
       // What redis server should we connect to for tasks / delayed jobs?
       redis: api.config.redis,
       // Customize Resque primitives, replace null with required replacement.
-      resque: {
+      resque_overrides: {
         queue: null,
         multiWorker: null,
         scheduler: null

--- a/config/tasks.js
+++ b/config/tasks.js
@@ -45,7 +45,7 @@ exports['default'] = {
       redis: api.config.redis,
       // Customize Resque primitives, replace null with required replacement.
       resque: {
-        queue: api.customResque.queue,
+        queue: null,
         multiWorker: null,
         scheduler: null
       }

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -7,6 +7,8 @@ module.exports = {
   stopPriority:  100,
   loadPriority:  600,
   initialize: function(api, next){
+    
+    var resqueOverrides = api.config.tasks.resque_overrides;
 
     api.resque = {
       verbose: false,
@@ -18,7 +20,7 @@ module.exports = {
       startQueue: function(callback){
         var self = this;
         var queue = NR.queue;
-        if(api.config.tasks.resque.queue){ queue = api.config.tasks.resque.queue; }
+        if(resqueOverrides && resqueOverrides.queue){ queue = resqueOverrides.queue; }
         self.queue = new queue({connection: self.connectionDetails}, api.tasks.jobs);
         self.queue.on('error', function(error){
           api.log(error, 'error', '[api.resque.queue]');
@@ -29,7 +31,7 @@ module.exports = {
       startScheduler: function(callback){
         var self = this;
         var scheduler = NR.scheduler;
-        if(api.config.tasks.resque.scheduler){ scheduler = api.config.tasks.scheduler; }
+        if(resqueOverrides && resqueOverrides.scheduler){ scheduler = resqueOverrides.scheduler; }
         if(api.config.tasks.scheduler === true){
           self.schedulerLogging = api.config.tasks.schedulerLogging;
           self.scheduler = new scheduler({connection: self.connectionDetails, timeout: api.config.tasks.timeout});
@@ -66,7 +68,7 @@ module.exports = {
       startMultiWorker: function(callback){
         var self = this;
         var multiWorker = NR.multiWorker;
-        if(api.config.tasks.resque.multiWorker){ multiWorker = api.config.tasks.resque.multiWorker; }
+        if(resqueOverrides && resqueOverrides.multiWorker){ multiWorker = resqueOverrides.multiWorker; }
         self.workerLogging = api.config.tasks.workerLogging;
         self.schedulerLogging = api.config.tasks.schedulerLogging;
 

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -17,7 +17,9 @@ module.exports = {
 
       startQueue: function(callback){
         var self = this;
-        self.queue = new NR.queue({connection: self.connectionDetails}, api.tasks.jobs);
+        var queue = NR.queue;
+        if(api.config.tasks.resque.queue){ queue = api.config.tasks.resque.queue; }
+        self.queue = new queue({connection: self.connectionDetails}, api.tasks.jobs);
         self.queue.on('error', function(error){
           api.log(error, 'error', '[api.resque.queue]');
         });
@@ -26,9 +28,11 @@ module.exports = {
 
       startScheduler: function(callback){
         var self = this;
+        var scheduler = NR.scheduler;
+        if(api.config.tasks.resque.scheduler){ scheduler = api.config.tasks.scheduler; }
         if(api.config.tasks.scheduler === true){
           self.schedulerLogging = api.config.tasks.schedulerLogging;
-          self.scheduler = new NR.scheduler({connection: self.connectionDetails, timeout: api.config.tasks.timeout});
+          self.scheduler = new scheduler({connection: self.connectionDetails, timeout: api.config.tasks.timeout});
           self.scheduler.on('error', function(error){
             api.log(error, 'error', '[api.resque.scheduler]');
           });
@@ -61,10 +65,12 @@ module.exports = {
 
       startMultiWorker: function(callback){
         var self = this;
+        var multiWorker = NR.multiWorker;
+        if(api.config.tasks.resque.multiWorker){ multiWorker = api.config.tasks.resque.multiWorker; }
         self.workerLogging = api.config.tasks.workerLogging;
         self.schedulerLogging = api.config.tasks.schedulerLogging;
 
-        self.multiWorker = new NR.multiWorker({
+        self.multiWorker = new multiWorker({
           connection:             api.resque.connectionDetails,
           queues:                 api.config.tasks.queues,
           timeout:                api.config.tasks.timeout,


### PR DESCRIPTION
Extending/modifying the current functionality of Resque within ActionHero is currently very cumbersome and has made upgrading our deployments very troublesome. I am proposing adding a configuration section to `config/tasks.js` to allow developers to replace the existing queues, scheduler, and multiWorkers with custom implementations. 

An example extension to queues: 
```javascript
'use strict';

var NR = require('node-resque');
var pluginRunner = require('../node_modules/node-resque/lib/pluginRunner.js');

//noinspection JSUnresolvedVariable
module.exports = {
  loadPriority:  590,
  initialize: function(api, next){
    api.customResque = {};
    
    let customQueue = NR.queue;
    
    customQueue.prototype.enqueueFront = function(q, func, args, callback){
      var self = this;
      if(arguments.length === 3 && typeof args === 'function'){
        callback = args;
        args = [];
      }else if(arguments.length < 3){
        args = [];
      }

      args = arrayify(args);
      var job = self.jobs[func];
      pluginRunner.runPlugins(self, 'before_enqueue', func, q, job, args, function(err, toRun){
        if(toRun === false){
          if(typeof callback === 'function'){ callback(err, toRun); }
        }else{
          self.connection.redis.sadd(self.connection.key('queues'), q, function(){
            self.connection.redis.lpush(self.connection.key('queue', q), self.encode(q, func, args), function(){
              pluginRunner.runPlugins(self, 'after_enqueue', func, q, job, args, function(){
                if(typeof callback === 'function'){ callback(err, toRun); }
              });
            });
          });
        }
      });
    };
    
    api.customResque.queue = customQueue;

    next();
  }
};
```