### PR TITLE
Fixes direct access of servers via api.servers.servers

### DIFF
--- a/initializers/servers.js
+++ b/initializers/servers.js
@@ -10,7 +10,7 @@ module.exports = {
   initialize: function(api, next){
 
     api.servers = {};
-    api.servers.servers = [];
+    api.servers.servers = {};
 
     // Load the servers
 


### PR DESCRIPTION
Found that `api.servers.servers` was empty when returning data to the client from an action. Looks like it was defined as an Array but then subsequently is used as an Object.
Changing it to Object allows us to stream results directly from an action to the client, e.g. `api.servers.servers.web.sendFile(connection, error, fileStream, mime, length, lastModified)`.