### PR TITLE
load apiVersion and serverName from package.json

### DIFF
--- a/actions/sleepTest.js
+++ b/actions/sleepTest.js
@@ -14,13 +14,7 @@ exports.sleepTest = {
     'sleepStarted':1420953571322,
     'sleepEnded':1420953572327,
     'sleepDelta':1005,
-    'sleepDuration':1000,
-    'serverInformation':{
-      'serverName':'actionhero API',
-      'apiVersion':'0.0.1',
-      'requestDuration':1006,
-      'currentTime':1420953572327
-    }
+    'sleepDuration':1000
   },
 
   run: function(api, data, next){

--- a/actions/status.js
+++ b/actions/status.js
@@ -5,13 +5,7 @@ exports.status = {
   outputExample:{
     'id':'192.168.2.11',
     'actionheroVersion':'9.4.1',
-    'uptime':10469,
-    'serverInformation':{
-      'serverName':'actionhero API',
-      'apiVersion':'0.0.1',
-      'requestDuration':12,
-      'currentTime':1420953679624
-    }
+    'uptime':10469
   },
 
   run: function(api, data, next){

--- a/config/api.js
+++ b/config/api.js
@@ -1,8 +1,12 @@
+var path = require('path');
+
 exports['default'] = {
   general: function(api){
+    var packageJSON = require(api.projectRoot + path.sep + 'package.json');
+
     return {
-      apiVersion: '0.0.1',
-      serverName: 'actionhero API',
+      apiVersion: packageJSON.version,
+      serverName: packageJSON.name,
       // id can be set here, or it will be generated dynamically.
       //  Be sure that every server you run has a unique ID (which will happen when generated dynamically)
       //  id: 'myActionHeroServer',

--- a/test/actions/showDocumentation.js
+++ b/test/actions/showDocumentation.js
@@ -21,7 +21,7 @@ describe('Action: Show Documentation', function(){
   it('returns the correct parts', function(done){
     api.specHelper.runAction('showDocumentation', function(response){
       Object.keys(response.documentation).length.should.equal(6); // 6 actions
-      response.serverInformation.serverName.should.equal('actionhero API');
+      response.serverInformation.serverName.should.equal('actionhero');
       done();
     });
   });

--- a/test/core/specHelper.js
+++ b/test/core/specHelper.js
@@ -30,7 +30,7 @@ describe('Core: specHelper', function(){
     api.specHelper.runAction('x', {thing: 'stuff'}, function(response){
       response.error.should.equal('Error: unknown action or invalid apiVersion');
       response.messageCount.should.equal(1);
-      response.serverInformation.serverName.should.equal('actionhero API');
+      response.serverInformation.serverName.should.equal('actionhero');
       response.requesterInformation.remoteIP.should.equal('testServer');
       done();
     });


### PR DESCRIPTION
load `api.config.general.apiVersion` and `api.config.general.serverName` from the equivalent fields in `package.json`

This is a breaking change.