### PR TITLE
Redis client

### DIFF
--- a/bin/templates/package.json
+++ b/bin/templates/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies" : {
     "actionhero" : "%%versionNumber%%",
-    "ws"         : "latest"
+    "ws"         : "latest",
+    "fakeredis"  : "latest"
   },
   "devDependencies" : {
     "mocha"  : "latest",

--- a/bin/templates/package.json
+++ b/bin/templates/package.json
@@ -9,7 +9,8 @@
   "dependencies" : {
     "actionhero" : "%%versionNumber%%",
     "ws"         : "latest",
-    "fakeredis"  : "latest"
+    "fakeredis"  : "latest",
+    "ioredis"    : "latest"
   },
   "devDependencies" : {
     "mocha"  : "latest",

--- a/config/api.js
+++ b/config/api.js
@@ -32,6 +32,10 @@ exports['default'] = {
       directoryFileType : 'index.html',
       // The default priority level given to middleware of all types (action, connection, and say)
       defaultMiddlewarePriority : 100,
+      // Which channel to use on redis pub/sub for RPC communication
+      channel: 'actionhero',
+      // How long to wait for an RPC call before considering it a failure
+      rpcTimeout: 5000,
       // configuration for your actionhero project structure
       paths: {
         'action':      [__dirname + '/../actions'],

--- a/config/redis.js
+++ b/config/redis.js
@@ -9,9 +9,9 @@ exports['default'] = {
     return {
       '_toExpand': false,
       // create the redis clients
-      client:     Redis.createClient(port, host),
-      subscriber: Redis.createClient(port, host),
-      tasks:      Redis.createClient(port, host),
+      client:     Redis.createClient(port, host, {fast: true}),
+      subscriber: Redis.createClient(port, host, {fast: true}),
+      tasks:      Redis.createClient(port, host, {fast: true}),
     };
   }
 };
@@ -32,9 +32,9 @@ exports.test = {
       return {
         '_toExpand': false,
 
-        client:     Redis.createClient(port, host),
-        subscriber: Redis.createClient(port, host),
-        tasks:      Redis.createClient(port, host),
+        client:     Redis.createClient(port, host, {fast: true}),
+        subscriber: Redis.createClient(port, host, {fast: true}),
+        tasks:      Redis.createClient(port, host, {fast: true}),
       };
     }
   }

--- a/config/redis.js
+++ b/config/redis.js
@@ -1,45 +1,46 @@
+var host     = process.env.REDIS_HOST || '127.0.0.1';
+var port     = process.env.REDIS_PORT || 6379;
+var database = process.env.REDIS_DB   || 0;
+
 exports['default'] = {
   redis: function(api){
-    var redisDetails = {
+    var Redis = require('fakeredis');
+
+    return {
+      '_toExpand': false,
+
       // Which channel to use on redis pub/sub for RPC communication
       channel: 'actionhero',
       // How long to wait for an RPC call before considering it a failure
       rpcTimeout: 5000,
-      // which redis package should you ise?
-      pkg: 'fakeredis',
-
-      // Basic configuration options
-      host     : process.env.REDIS_HOST || '127.0.0.1',
-      port     : process.env.REDIS_PORT || 6379,
-      database : process.env.REDIS_DB   || 0,
+      // create the redis clients
+      client:     Redis.createClient(port, host),
+      subscriber: Redis.createClient(port, host),
+      tasks:      Redis.createClient(port, host),
     };
-
-    if(process.env.FAKEREDIS === 'false' || process.env.REDIS_HOST !== undefined){
-      redisDetails.pkg  = 'ioredis';
-      // there are many more connection options, including support for cluster and sentinel
-      // learn more @ https://github.com/luin/ioredis
-      redisDetails.options  = {
-        password: (process.env.REDIS_PASS || null),
-      };
-    }
-
-    return redisDetails;
   }
 };
 
 exports.test = {
   redis: function(api){
-    var pkg = 'fakeredis';
     if(process.env.FAKEREDIS === 'false'){
-      pkg = 'ioredis';
-    }
+      var Redis = require('ioredis');
+      return {
+        '_toExpand': false,
 
-    return {
-      pkg: pkg,
-      host: '127.0.0.1',
-      port: 6379,
-      database: 2,
-      options: {},
-    };
+        client:     new Redis({host: host, port: port, db: database}),
+        subscriber: new Redis({host: host, port: port, db: database}),
+        tasks:      new Redis({host: host, port: port, db: database}),
+      };
+    }else{
+      var Redis = require('fakeredis');
+      return {
+        '_toExpand': false,
+
+        client:     Redis.createClient(port, host),
+        subscriber: Redis.createClient(port, host),
+        tasks:      Redis.createClient(port, host),
+      };
+    }
   }
 };

--- a/config/redis.js
+++ b/config/redis.js
@@ -8,11 +8,6 @@ exports['default'] = {
 
     return {
       '_toExpand': false,
-
-      // Which channel to use on redis pub/sub for RPC communication
-      channel: 'actionhero',
-      // How long to wait for an RPC call before considering it a failure
-      rpcTimeout: 5000,
       // create the redis clients
       client:     Redis.createClient(port, host),
       subscriber: Redis.createClient(port, host),

--- a/config/tasks.js
+++ b/config/tasks.js
@@ -41,8 +41,6 @@ exports['default'] = {
       maxEventLoopDelay: 5,
       // When we kill off a taskProcessor, should we disconnect that local redis connection?
       toDisconnectProcessors: true,
-      // What redis server should we connect to for tasks / delayed jobs?
-      redis: api.config.redis,
       // Customize Resque primitives, replace null with required replacement.
       resque_overrides: {
         queue: null,

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -221,7 +221,7 @@ module.exports = {
           if(typeof callback === 'function'){ callback(api.config.errors.connectionAlreadyInRoom(connection, room), false); }
         }
       }else{
-        api.config.redis.doCluster('api.chatRoom.addMember', [connectionId, room], connectionId, callback);
+        api.redis.doCluster('api.chatRoom.addMember', [connectionId, room], connectionId, callback);
       }
     };
 
@@ -250,7 +250,7 @@ module.exports = {
           if(typeof callback === 'function'){ callback(api.config.errors.connectionNotInRoom(connection, room), false); }
         }
       }else{
-        api.config.redis.doCluster('api.chatRoom.removeMember', [connectionId, room], connectionId, callback);
+        api.redis.doCluster('api.chatRoom.removeMember', [connectionId, room], connectionId, callback);
       }
     };
 

--- a/initializers/config.js
+++ b/initializers/config.js
@@ -127,8 +127,14 @@ module.exports = {
           // error loading configuration, abort if all remaining
           // configuration files have been tried and failed
           // indicating inability to progress
-          loadErrors[f] = error.toString();
+          loadErrors[f] = {error: error, msg: error.toString()};
           if(++loadRetries === limit - i){
+            Object.keys(loadErrors).forEach(function(e){
+              console.log(loadErrors[e].error.stack);
+              console.log('');
+              delete loadErrors[e].error;
+            });
+
             throw new Error('Unable to load configurations, errors: ' + JSON.stringify(loadErrors));
           }
           // adjust configuration files list: remove and push

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -19,12 +19,12 @@ module.exports = {
     api.redis.initialize = function(callback){
 
       if(!api.redis.status.subscribed){
-        api.config.redis.subscriber.subscribe(api.config.redis.channel);
+        api.config.redis.subscriber.subscribe(api.config.general.channel);
         api.redis.status.subscribed = true;
 
         api.config.redis.subscriber.on('message', function(messageChannel, message){
           try{ message = JSON.parse(message); }catch(e){ message = {}; }
-          if(messageChannel === api.config.redis.channel && message.serverToken === api.config.general.serverToken){
+          if(messageChannel === api.config.general.channel && message.serverToken === api.config.general.serverToken){
             if(api.redis.subscriptionHandlers[message.messageType]){
               api.redis.subscriptionHandlers[message.messageType](message);
             }
@@ -53,7 +53,7 @@ module.exports = {
     };
 
     api.redis.publish = function(payload){
-      var channel = api.config.redis.channel;
+      var channel = api.config.general.channel;
       api.config.redis.client.publish(channel, JSON.stringify(payload));
     };
 
@@ -113,7 +113,7 @@ module.exports = {
           }
           delete api.redis.clusterCallbaks[requestId];
           delete api.redis.clusterCallbakTimeouts[requestId];
-        }, api.config.redis.rpcTimeout, requestId);
+        }, api.config.general.rpcTimeout, requestId);
       }
     };
 

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -7,7 +7,7 @@ module.exports = {
   stopPriority:  100,
   loadPriority:  600,
   initialize: function(api, next){
-    
+
     var resqueOverrides = api.config.tasks.resque_overrides;
 
     api.resque = {
@@ -15,7 +15,7 @@ module.exports = {
       queue: null,
       multiWorker: null,
       scheduler: null,
-      connectionDetails: api.config.tasks.redis || {},
+      connectionDetails: {redis: api.config.redis.tasks},
 
       startQueue: function(callback){
         var self = this;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ioredis": "^1.15.1",
     "is-running": "^2.0.0",
     "mime": "^1.3.4",
-    "node-resque": "^2.0.5",
+    "node-resque": "^2.0.6",
     "node-uuid": "^1.4.4",
     "optimist": "^0.6.1",
     "primus": "^5.2.1",

--- a/site/source/includes/docs/core/action_cluster.md
+++ b/site/source/includes/docs/core/action_cluster.md
@@ -29,7 +29,7 @@ If you wanted the node which holds connection `abc123` to change their `authoriz
 
 The RPC system is used heavily by Chat.
 
-Two options have been added to the `config/redis.js` config file to support this: `api.config.redis.channel` ( Which channel to use on redis pub/sub for RPC communication ) and `api.config.redis.rpcTimeout` ( How long to wait for an RPC call before considering it a failure )
+Two options have been added to the `config/redis.js` config file to support this: `api.config.general.channel` ( Which channel to use on redis pub/sub for RPC communication ) and `api.config.general.rpcTimeout` ( How long to wait for an RPC call before considering it a failure )
 
 **WARNING**
 

--- a/test/core/actionCluster.js
+++ b/test/core/actionCluster.js
@@ -247,7 +247,7 @@ describe('Core: Action Cluster', function(){
       });
 
       it('failing RPC calls with a callback will have a failure callback', function(done){
-        this.timeout(apiA.config.redis.rpcTimeout * 3);
+        this.timeout(apiA.config.general.rpcTimeout * 3);
 
         apiB.redis.doCluster('api.rpcTestMethod', [], 'A missing clientId', function(error){
           String(error).should.equal('Error: RPC Timeout');

--- a/test/core/binary.js
+++ b/test/core/binary.js
@@ -94,6 +94,17 @@ describe('Core: Binary', function(){
       });
     });
 
+    it('can call npm install in the new project', function(done){
+      this.timeout(1000 * 60);
+      doBash([
+        'cd ' + testDir,
+        'npm install'
+      ], function(error, data){
+        should.not.exist(error);
+        done();
+      });
+    });
+
     it('can call the help command', function(done){
       doBash([
         'cd ' + testDir,

--- a/test/core/cache.js
+++ b/test/core/cache.js
@@ -285,7 +285,7 @@ describe('Core: Cache', function(){
     it('locks have a TTL and the default will be assumed from config', function(done){
       api.cache.lock(key, null, function(error, lockOk){
         lockOk.should.equal(true);
-        api.redis.client.ttl(api.cache.lockPrefix + key, function(error, ttl){
+        api.config.redis.client.ttl(api.cache.lockPrefix + key, function(error, ttl){
           (ttl >= 9).should.equal(true);
           (ttl <= 10).should.equal(true);
           done();


### PR DESCRIPTION
There are **so many** ways to configure redis these days... handling the config options for all of them (sentinel?  cluster?) is a pain... so lets just let the users configure things directly.  It will be so much simpler!

---

### This will be a breaking change


- in `config/redis.js`, you now define the 3 redis connections you need explicitly rather than passing config options around:
```js
var host     = process.env.REDIS_HOST || '127.0.0.1';
var port     = process.env.REDIS_PORT || 6379;
var database = process.env.REDIS_DB   || 0;

exports['default'] = {
  redis: function(api){
    var Redis = require('ioredis');

    return {
      '_toExpand': false,
      // create the redis clients
      client:     Redis.createClient(port, host),
      subscriber: Redis.createClient(port, host),
      tasks:      Redis.createClient(port, host),
    };
  }
};

```
- move `api.config.redis.channel` to `api.config.general.channel`
- move `api.config.redis. rpcTimeout` to `api.config.general. rpcTimeout`
- throughout the code, use `api.config.redis.client` rather than `api.redis.client`