### PR TITLE
V14.0.0

### DIFF
--- a/bin/templates/package.json
+++ b/bin/templates/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies" : {
     "actionhero" : "%%versionNumber%%",
-    "ws"         : "latest"
+    "ws"         : "latest",
+    "fakeredis"  : "latest"
   },
   "devDependencies" : {
     "mocha"  : "latest",

--- a/bin/templates/package.json
+++ b/bin/templates/package.json
@@ -9,7 +9,8 @@
   "dependencies" : {
     "actionhero" : "%%versionNumber%%",
     "ws"         : "latest",
-    "fakeredis"  : "latest"
+    "fakeredis"  : "latest",
+    "ioredis"    : "latest"
   },
   "devDependencies" : {
     "mocha"  : "latest",

--- a/config/api.js
+++ b/config/api.js
@@ -36,6 +36,10 @@ exports['default'] = {
       directoryFileType : 'index.html',
       // The default priority level given to middleware of all types (action, connection, and say)
       defaultMiddlewarePriority : 100,
+      // Which channel to use on redis pub/sub for RPC communication
+      channel: 'actionhero',
+      // How long to wait for an RPC call before considering it a failure
+      rpcTimeout: 5000,
       // configuration for your actionhero project structure
       paths: {
         'action':      [__dirname + '/../actions'],

--- a/config/errors.js
+++ b/config/errors.js
@@ -49,7 +49,8 @@ exports['default'] = {
 
       // When a params for an action is invalid
       invalidParams: function(data, validationErrors){
-        return validationErrors.join(', ');
+        if(validationErrors.length >= 0){ return validationErrors[0]; }
+        return 'validation error';
       },
 
       // When a required param for an action is not provided

--- a/config/redis.js
+++ b/config/redis.js
@@ -9,9 +9,9 @@ exports['default'] = {
     return {
       '_toExpand': false,
       // create the redis clients
-      client:     Redis.createClient(port, host),
-      subscriber: Redis.createClient(port, host),
-      tasks:      Redis.createClient(port, host),
+      client:     Redis.createClient(port, host, {fast: true}),
+      subscriber: Redis.createClient(port, host, {fast: true}),
+      tasks:      Redis.createClient(port, host, {fast: true}),
     };
   }
 };
@@ -32,9 +32,9 @@ exports.test = {
       return {
         '_toExpand': false,
 
-        client:     Redis.createClient(port, host),
-        subscriber: Redis.createClient(port, host),
-        tasks:      Redis.createClient(port, host),
+        client:     Redis.createClient(port, host, {fast: true}),
+        subscriber: Redis.createClient(port, host, {fast: true}),
+        tasks:      Redis.createClient(port, host, {fast: true}),
       };
     }
   }

--- a/config/redis.js
+++ b/config/redis.js
@@ -1,45 +1,46 @@
+var host     = process.env.REDIS_HOST || '127.0.0.1';
+var port     = process.env.REDIS_PORT || 6379;
+var database = process.env.REDIS_DB   || 0;
+
 exports['default'] = {
   redis: function(api){
-    var redisDetails = {
+    var Redis = require('fakeredis');
+
+    return {
+      '_toExpand': false,
+
       // Which channel to use on redis pub/sub for RPC communication
       channel: 'actionhero',
       // How long to wait for an RPC call before considering it a failure
       rpcTimeout: 5000,
-      // which redis package should you ise?
-      pkg: 'fakeredis',
-
-      // Basic configuration options
-      host     : process.env.REDIS_HOST || '127.0.0.1',
-      port     : process.env.REDIS_PORT || 6379,
-      database : process.env.REDIS_DB   || 0,
+      // create the redis clients
+      client:     Redis.createClient(port, host),
+      subscriber: Redis.createClient(port, host),
+      tasks:      Redis.createClient(port, host),
     };
-
-    if(process.env.FAKEREDIS === 'false' || process.env.REDIS_HOST !== undefined){
-      redisDetails.pkg  = 'ioredis';
-      // there are many more connection options, including support for cluster and sentinel
-      // learn more @ https://github.com/luin/ioredis
-      redisDetails.options  = {
-        password: (process.env.REDIS_PASS || null),
-      };
-    }
-
-    return redisDetails;
   }
 };
 
 exports.test = {
   redis: function(api){
-    var pkg = 'fakeredis';
     if(process.env.FAKEREDIS === 'false'){
-      pkg = 'ioredis';
-    }
+      var Redis = require('ioredis');
+      return {
+        '_toExpand': false,
 
-    return {
-      pkg: pkg,
-      host: '127.0.0.1',
-      port: 6379,
-      database: 2,
-      options: {},
-    };
+        client:     new Redis({host: host, port: port, db: database}),
+        subscriber: new Redis({host: host, port: port, db: database}),
+        tasks:      new Redis({host: host, port: port, db: database}),
+      };
+    }else{
+      var Redis = require('fakeredis');
+      return {
+        '_toExpand': false,
+
+        client:     Redis.createClient(port, host),
+        subscriber: Redis.createClient(port, host),
+        tasks:      Redis.createClient(port, host),
+      };
+    }
   }
 };

--- a/config/redis.js
+++ b/config/redis.js
@@ -8,11 +8,6 @@ exports['default'] = {
 
     return {
       '_toExpand': false,
-
-      // Which channel to use on redis pub/sub for RPC communication
-      channel: 'actionhero',
-      // How long to wait for an RPC call before considering it a failure
-      rpcTimeout: 5000,
       // create the redis clients
       client:     Redis.createClient(port, host),
       subscriber: Redis.createClient(port, host),

--- a/config/redis.js
+++ b/config/redis.js
@@ -4,7 +4,12 @@ var database = process.env.REDIS_DB   || 0;
 
 exports['default'] = {
   redis: function(api){
-    var Redis = require('fakeredis');
+    var Redis;
+    if(process.env.FAKEREDIS === 'false' || process.env.REDIS_HOST !== undefined){
+      Redis = require('ioredis');
+    }else{
+      Redis = require('fakeredis');
+    }
 
     return {
       '_toExpand': false,

--- a/config/tasks.js
+++ b/config/tasks.js
@@ -41,8 +41,6 @@ exports['default'] = {
       maxEventLoopDelay: 5,
       // When we kill off a taskProcessor, should we disconnect that local redis connection?
       toDisconnectProcessors: true,
-      // What redis server should we connect to for tasks / delayed jobs?
-      redis: api.config.redis,
       // Customize Resque primitives, replace null with required replacement.
       resque_overrides: {
         queue: null,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   redis:
     image: redis
   actionhero:
-    build: .
+    image: evantahler/actionhero
     ports:
      - 8080
      - 5000

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -6,6 +6,13 @@ module.exports = {
   loadPriority:  430,
   initialize: function(api, next){
 
+    var prepareStringMethod = function(method){
+      var cmdParts = method.split('.');
+      var cmd = cmdParts.shift();
+      if(cmd !== 'api'){ throw new Error('cannot operate on a method outside of the api object'); }
+      return api.utils.stringToHash(cmdParts.join('.'));
+    };
+
     api.actionProcessor = function(connection, callback){
       if(!connection){
         throw new Error('data.connection is required');
@@ -205,7 +212,7 @@ module.exports = {
             if(typeof formatter === 'function'){
               self.params[key] = formatter.call(api, self.params[key], self);
             }else{
-              var method = api.utils.stringToHash(formatter);
+              var method = prepareStringMethod(formatter);
               self.params[key] = method.call(api, self.params[key], self);
             }
           });
@@ -220,7 +227,7 @@ module.exports = {
             if(typeof validator === 'function'){
               validatorResponse = validator.call(api, self.params[key], self);
             }else{
-              var method = api.utils.stringToHash(validator);
+              var method = prepareStringMethod(validator);
               validatorResponse = method.call(api, self.params[key], self);
             }
             if(validatorResponse !== true){ self.validatorErrors.push(validatorResponse); }

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -198,16 +198,33 @@ module.exports = {
         }
 
         // formatter
-        if(self.params[key] !== undefined && typeof props.formatter === 'function'){
-          self.params[key] = props.formatter.call(api, self.params[key], self);
+        if(self.params[key] !== undefined && props.formatter !== undefined){
+          if(!Array.isArray(props.formatter)){ props.formatter = [props.formatter]; }
+
+          props.formatter.forEach(function(formatter){
+            if(typeof formatter === 'function'){
+              self.params[key] = formatter.call(api, self.params[key], self);
+            }else{
+              var method = api.utils.stringToHash(formatter);
+              self.params[key] = method.call(api, self.params[key], self);
+            }
+          });
         }
 
         // validator
-        if(self.params[key] !== undefined && typeof props.validator === 'function'){
-          var validatorResponse = props.validator.call(api, self.params[key], self);
-          if(validatorResponse !== true){
-            self.validatorErrors.push(validatorResponse);
-          }
+        if(self.params[key] !== undefined && props.validator !== undefined){
+          if(!Array.isArray(props.validator)){ props.validator = [props.validator]; }
+
+          props.validator.forEach(function(validator){
+            var validatorResponse;
+            if(typeof validator === 'function'){
+              validatorResponse = validator.call(api, self.params[key], self);
+            }else{
+              var method = api.utils.stringToHash(validator);
+              validatorResponse = method.call(api, self.params[key], self);
+            }
+            if(validatorResponse !== true){ self.validatorErrors.push(validatorResponse); }
+          });
         }
 
         // required

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -221,7 +221,7 @@ module.exports = {
           if(typeof callback === 'function'){ callback(api.config.errors.connectionAlreadyInRoom(connection, room), false); }
         }
       }else{
-        api.config.redis.doCluster('api.chatRoom.addMember', [connectionId, room], connectionId, callback);
+        api.redis.doCluster('api.chatRoom.addMember', [connectionId, room], connectionId, callback);
       }
     };
 
@@ -250,7 +250,7 @@ module.exports = {
           if(typeof callback === 'function'){ callback(api.config.errors.connectionNotInRoom(connection, room), false); }
         }
       }else{
-        api.config.redis.doCluster('api.chatRoom.removeMember', [connectionId, room], connectionId, callback);
+        api.redis.doCluster('api.chatRoom.removeMember', [connectionId, room], connectionId, callback);
       }
     };
 

--- a/initializers/config.js
+++ b/initializers/config.js
@@ -127,8 +127,14 @@ module.exports = {
           // error loading configuration, abort if all remaining
           // configuration files have been tried and failed
           // indicating inability to progress
-          loadErrors[f] = error.toString();
+          loadErrors[f] = {error: error, msg: error.toString()};
           if(++loadRetries === limit - i){
+            Object.keys(loadErrors).forEach(function(e){
+              console.log(loadErrors[e].error.stack);
+              console.log('');
+              delete loadErrors[e].error;
+            });
+
             throw new Error('Unable to load configurations, errors: ' + JSON.stringify(loadErrors));
           }
           // adjust configuration files list: remove and push

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -19,12 +19,12 @@ module.exports = {
     api.redis.initialize = function(callback){
 
       if(!api.redis.status.subscribed){
-        api.config.redis.subscriber.subscribe(api.config.redis.channel);
+        api.config.redis.subscriber.subscribe(api.config.general.channel);
         api.redis.status.subscribed = true;
 
         api.config.redis.subscriber.on('message', function(messageChannel, message){
           try{ message = JSON.parse(message); }catch(e){ message = {}; }
-          if(messageChannel === api.config.redis.channel && message.serverToken === api.config.general.serverToken){
+          if(messageChannel === api.config.general.channel && message.serverToken === api.config.general.serverToken){
             if(api.redis.subscriptionHandlers[message.messageType]){
               api.redis.subscriptionHandlers[message.messageType](message);
             }
@@ -53,7 +53,7 @@ module.exports = {
     };
 
     api.redis.publish = function(payload){
-      var channel = api.config.redis.channel;
+      var channel = api.config.general.channel;
       api.config.redis.client.publish(channel, JSON.stringify(payload));
     };
 
@@ -113,7 +113,7 @@ module.exports = {
           }
           delete api.redis.clusterCallbaks[requestId];
           delete api.redis.clusterCallbakTimeouts[requestId];
-        }, api.config.redis.rpcTimeout, requestId);
+        }, api.config.general.rpcTimeout, requestId);
       }
     };
 

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -7,7 +7,7 @@ module.exports = {
   stopPriority:  100,
   loadPriority:  600,
   initialize: function(api, next){
-    
+
     var resqueOverrides = api.config.tasks.resque_overrides;
 
     api.resque = {
@@ -15,7 +15,7 @@ module.exports = {
       queue: null,
       multiWorker: null,
       scheduler: null,
-      connectionDetails: api.config.tasks.redis || {},
+      connectionDetails: {redis: api.config.redis.tasks},
 
       startQueue: function(callback){
         var self = this;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ioredis": "^2.1.0",
     "is-running": "^2.0.0",
     "mime": "^1.3.4",
-    "node-resque": "^2.0.5",
+    "node-resque": "^2.0.6",
     "node-uuid": "^1.4.4",
     "optimist": "^0.6.1",
     "primus": "^5.2.2",

--- a/site/source/includes/docs/core/action_cluster.md
+++ b/site/source/includes/docs/core/action_cluster.md
@@ -29,7 +29,7 @@ If you wanted the node which holds connection `abc123` to change their `authoriz
 
 The RPC system is used heavily by Chat.
 
-Two options have been added to the `config/redis.js` config file to support this: `api.config.redis.channel` ( Which channel to use on redis pub/sub for RPC communication ) and `api.config.redis.rpcTimeout` ( How long to wait for an RPC call before considering it a failure )
+Two options have been added to the `config/redis.js` config file to support this: `api.config.general.channel` ( Which channel to use on redis pub/sub for RPC communication ) and `api.config.general.rpcTimeout` ( How long to wait for an RPC call before considering it a failure )
 
 **WARNING**
 

--- a/site/source/includes/docs/core/actions.md
+++ b/site/source/includes/docs/core/actions.md
@@ -239,6 +239,53 @@ moneyInCents: {
 - If moneyInCents = `null`    => 0 (default value)
 - If moneyInCents = `"hello"` => Error('not a number')
 
+Formatters and Validators can also be named method names. For example, you might have an action like:
+
+```js
+exports.cacheTest = {
+  name: 'cacheTest',
+  description: 'I will test the internal cache functions of the API',
+  outputExample: {},
+
+  inputs: {
+    key: {
+      required: true,
+      formatter: [
+         function(s){ return String(s); },
+         'api.formatter.uniqueKeyName' // <----------- HERE
+    },
+    value: {
+      required: true,
+      formatter: function(s){ return String(s); },
+      validator: function(s){
+        if(s.length < 3){ return '`value` should be at least 3 letters long'; }
+        else{ return true; }
+      }
+    },
+  },
+
+  run: function(api, data, next){
+    // ...
+  }
+
+};
+```
+
+You can define `api.formatter.uniqueKeyName` elsewhere in your project, like this initializer:
+
+```js
+module.exports = {
+  initialize: function(api, next){
+    api.formatter = {
+      uniqueKeyName: function(key){
+        return key + '-' + this.connection.id;
+      }
+    };
+
+    next();
+  },
+};
+```
 
 ## The Data Object
 

--- a/test/core/actionCluster.js
+++ b/test/core/actionCluster.js
@@ -247,7 +247,7 @@ describe('Core: Action Cluster', function(){
       });
 
       it('failing RPC calls with a callback will have a failure callback', function(done){
-        this.timeout(apiA.config.redis.rpcTimeout * 3);
+        this.timeout(apiA.config.general.rpcTimeout * 3);
 
         apiB.redis.doCluster('api.rpcTestMethod', [], 'A missing clientId', function(error){
           String(error).should.equal('Error: RPC Timeout');

--- a/test/core/binary.js
+++ b/test/core/binary.js
@@ -94,6 +94,17 @@ describe('Core: Binary', function(){
       });
     });
 
+    it('can call npm install in the new project', function(done){
+      this.timeout(1000 * 60);
+      doBash([
+        'cd ' + testDir,
+        'npm install'
+      ], function(error, data){
+        should.not.exist(error);
+        done();
+      });
+    });
+
     it('can call the help command', function(done){
       doBash([
         'cd ' + testDir,

--- a/test/core/cache.js
+++ b/test/core/cache.js
@@ -285,7 +285,7 @@ describe('Core: Cache', function(){
     it('locks have a TTL and the default will be assumed from config', function(done){
       api.cache.lock(key, null, function(error, lockOk){
         lockOk.should.equal(true);
-        api.redis.client.ttl(api.cache.lockPrefix + key, function(error, ttl){
+        api.config.redis.client.ttl(api.cache.lockPrefix + key, function(error, ttl){
           (ttl >= 9).should.equal(true);
           (ttl <= 10).should.equal(true);
           done();


### PR DESCRIPTION
# Named Validators
Allows for action validators and formatters to use both named methods and direction functions.

```js
exports.cacheTest = {
  name: 'cacheTest',
  description: 'I will test the internal cache functions of the API',
  outputExample: {},

  inputs: {
    key: {
      required: true,
      formatter: [
         function(s){ return String(s); },
         'api.formatter.uniqueKeyName' // <----------- HERE
    },
    value: {
      required: true,
      formatter: function(s){ return String(s); },
      validator: function(s){
        if(s.length < 3){ return '`value` should be at least 3 letters long'; }
        else{ return true; }
      }
    },
  },

  run: function(api, data, next){
    // ...
  }

};
```

And then you would define an initializer with your formatter:

```js
'use strict';

module.exports = {
  initialize: function(api, next){
    api.formatter = {
      uniqueKeyName: function(key){
        return key + '-' + this.connection.id;
      }
    };

    next();
  },
};
```
- by @evantahler via https://github.com/evantahler/actionhero/pull/876

# Redis Client 

There are **so many** ways to configure redis these days... handling the config options for all of them (sentinel?  cluster?) is a pain... so lets just let the users configure things directly.  It will be so much simpler!

### This will be a breaking change

- in `config/redis.js`, you now define the 3 redis connections you need explicitly rather than passing config options around:
```js
var host     = process.env.REDIS_HOST || '127.0.0.1';
var port     = process.env.REDIS_PORT || 6379;
var database = process.env.REDIS_DB   || 0;

exports['default'] = {
  redis: function(api){
    var Redis = require('ioredis');

    return {
      '_toExpand': false,
      // create the redis clients
      client:     Redis.createClient(port, host),
      subscriber: Redis.createClient(port, host),
      tasks:      Redis.createClient(port, host),
    };
  }
};

```
- move `api.config.redis.channel` to `api.config.general.channel`
- move `api.config.redis. rpcTimeout` to `api.config.general. rpcTimeout`
- throughout the code, use `api.config.redis.client` rather than `api.redis.client`