### PR TITLE
Electron support, avoid bug electron/electron#5454

### DIFF
--- a/initializers/utils.js
+++ b/initializers/utils.js
@@ -100,11 +100,10 @@ module.exports = {
       if(!followLinkFiles){ followLinkFiles = true; }
 
       extension = extension.replace('.', '');
-      if(dir[dir.length - 1] !== path.sep){ dir += path.sep; }
 
       if(fs.existsSync(dir)){
         fs.readdirSync(dir).forEach(function(file){
-          var fullFilePath = path.normalize(dir + file);
+          var fullFilePath = path.join(dir, file);
           if(file[0] !== '.'){ // ignore 'system' files
             var stats = fs.statSync(fullFilePath);
             var child;


### PR DESCRIPTION
There's a bug in Electron causing directory listing of an ASAR subdirectory to return a listing of the ASAR root, when the path to list has a trailing slash.  To fix:
- remove trailing path separator from `dir` in recursive directory glob
- use path.join(dir, file) instead of path.normalize(dir + file)