### PR TITLE
Delay log directory creation until after configs are loaded

### DIFF
--- a/config/logger.js
+++ b/config/logger.js
@@ -17,18 +17,18 @@ exports['default'] = {
     }
 
     // file logger
-    if(api.config.general.paths.log.length === 1){
-      var logDirectory = api.config.general.paths.log[0];
-      try{
-        fs.mkdirSync(logDirectory);
-      }catch(e){
-        if(e.code !== 'EEXIST'){
-          throw(new Error('Cannot create log directory @ ' + logDirectory));
+    logger.transports.push(function(api, winston){
+      if(api.config.general.paths.log.length === 1){
+        var logDirectory = api.config.general.paths.log[0];
+        try{
+          fs.mkdirSync(logDirectory);
+        }catch(e){
+          if(e.code !== 'EEXIST'){
+            throw(new Error('Cannot create log directory @ ' + logDirectory));
+          }
         }
       }
-    }
 
-    logger.transports.push(function(api, winston){
       return new (winston.transports.File)({
         filename: api.config.general.paths.log[0] + '/' + api.pids.title + '.log',
         level: 'info',


### PR DESCRIPTION
Support for Actionhero installed on a read-only filesystem.

Actionhero checks to ensure its log directory exists by trying to create the log directory.  It does this during config loading.  As a result, when loading the default config it tries to make a log dir inside the node_modules directory.  If that directory is on a read-only filesystem we crash.

One possible solution (presented here) is to delay the directory creation check until after all configs have been loaded.  This way even if Actionhero is installed on a read-only filesystem, the user can provide an alternate log location on a writable filesystem, and we won't try to create any log directories until all configs have been loaded.