### PR TITLE
remove vestigial code fragment from comment

### DIFF
--- a/bin/templates/task.js
+++ b/bin/templates/task.js
@@ -9,7 +9,7 @@ exports.task = {
   pluginOptions: {},
 
   run: function(api, params, next){
-    // your logic here');
+    // your logic here
     next();
   }
 };


### PR DESCRIPTION
comment contains '); which seems to be a remnant of some old code, it is out of place now in the comment