### PR TITLE
Named validators

### DIFF
--- a/config/errors.js
+++ b/config/errors.js
@@ -49,7 +49,8 @@ exports['default'] = {
 
       // When a params for an action is invalid
       invalidParams: function(data, validationErrors){
-        return validationErrors.join(', ');
+        if(validationErrors.length >= 0){ return validationErrors[0]; }
+        return 'validation error';
       },
 
       // When a required param for an action is not provided

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -6,6 +6,13 @@ module.exports = {
   loadPriority:  430,
   initialize: function(api, next){
 
+    var prepareStringMethod = function(method){
+      var cmdParts = method.split('.');
+      var cmd = cmdParts.shift();
+      if(cmd !== 'api'){ throw new Error('cannot operate on a method outside of the api object'); }
+      return api.utils.stringToHash(cmdParts.join('.'));
+    };
+
     api.actionProcessor = function(connection, callback){
       if(!connection){
         throw new Error('data.connection is required');
@@ -205,7 +212,7 @@ module.exports = {
             if(typeof formatter === 'function'){
               self.params[key] = formatter.call(api, self.params[key], self);
             }else{
-              var method = api.utils.stringToHash(formatter);
+              var method = prepareStringMethod(formatter);
               self.params[key] = method.call(api, self.params[key], self);
             }
           });
@@ -220,7 +227,7 @@ module.exports = {
             if(typeof validator === 'function'){
               validatorResponse = validator.call(api, self.params[key], self);
             }else{
-              var method = api.utils.stringToHash(validator);
+              var method = prepareStringMethod(validator);
               validatorResponse = method.call(api, self.params[key], self);
             }
             if(validatorResponse !== true){ self.validatorErrors.push(validatorResponse); }

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -198,16 +198,33 @@ module.exports = {
         }
 
         // formatter
-        if(self.params[key] !== undefined && typeof props.formatter === 'function'){
-          self.params[key] = props.formatter.call(api, self.params[key], self);
+        if(self.params[key] !== undefined && props.formatter !== undefined){
+          if(!Array.isArray(props.formatter)){ props.formatter = [props.formatter]; }
+
+          props.formatter.forEach(function(formatter){
+            if(typeof formatter === 'function'){
+              self.params[key] = formatter.call(api, self.params[key], self);
+            }else{
+              var method = api.utils.stringToHash(formatter);
+              self.params[key] = method.call(api, self.params[key], self);
+            }
+          });
         }
 
         // validator
-        if(self.params[key] !== undefined && typeof props.validator === 'function'){
-          var validatorResponse = props.validator.call(api, self.params[key], self);
-          if(validatorResponse !== true){
-            self.validatorErrors.push(validatorResponse);
-          }
+        if(self.params[key] !== undefined && props.validator !== undefined){
+          if(!Array.isArray(props.validator)){ props.validator = [props.validator]; }
+
+          props.validator.forEach(function(validator){
+            var validatorResponse;
+            if(typeof validator === 'function'){
+              validatorResponse = validator.call(api, self.params[key], self);
+            }else{
+              var method = api.utils.stringToHash(validator);
+              validatorResponse = method.call(api, self.params[key], self);
+            }
+            if(validatorResponse !== true){ self.validatorErrors.push(validatorResponse); }
+          });
         }
 
         // required

--- a/site/source/includes/docs/core/actions.md
+++ b/site/source/includes/docs/core/actions.md
@@ -239,6 +239,53 @@ moneyInCents: {
 - If moneyInCents = `null`    => 0 (default value)
 - If moneyInCents = `"hello"` => Error('not a number')
 
+Formatters and Validators can also be named method names. For example, you might have an action like:
+
+```js
+exports.cacheTest = {
+  name: 'cacheTest',
+  description: 'I will test the internal cache functions of the API',
+  outputExample: {},
+
+  inputs: {
+    key: {
+      required: true,
+      formatter: [
+         function(s){ return String(s); },
+         'api.formatter.uniqueKeyName' // <----------- HERE
+    },
+    value: {
+      required: true,
+      formatter: function(s){ return String(s); },
+      validator: function(s){
+        if(s.length < 3){ return '`value` should be at least 3 letters long'; }
+        else{ return true; }
+      }
+    },
+  },
+
+  run: function(api, data, next){
+    // ...
+  }
+
+};
+```
+
+You can define `api.formatter.uniqueKeyName` elsewhere in your project, like this initializer:
+
+```js
+module.exports = {
+  initialize: function(api, next){
+    api.formatter = {
+      uniqueKeyName: function(key){
+        return key + '-' + this.connection.id;
+      }
+    };
+
+    next();
+  },
+};
+```
 
 ## The Data Object
 


### PR DESCRIPTION
allows for action validators and formatters to use both named methods and direction functions.

```js
exports.cacheTest = {
  name: 'cacheTest',
  description: 'I will test the internal cache functions of the API',
  outputExample: {},

  inputs: {
    key: {
      required: true,
      formatter: [
         function(s){ return String(s); },
         'api.formatter.uniqueKeyName' // <----------- HERE
    },
    value: {
      required: true,
      formatter: function(s){ return String(s); },
      validator: function(s){
        if(s.length < 3){ return '`value` should be at least 3 letters long'; }
        else{ return true; }
      }
    },
  },

  run: function(api, data, next){
    // ...
  }

};
```

And then you would define an initializer with your formatter:

```js
'use strict';

module.exports = {
  initialize: function(api, next){
    api.formatter = {
      uniqueKeyName: function(key){
        return key + '-' + this.connection.id;
      }
    };

    next();
  },
};
```