### PR TITLE
spec helper should have fingerprint

### DIFF
--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -120,7 +120,7 @@ module.exports = {
 
       var connectionDefaults = {
         error: null,
-        fingerprint: null,
+        fingerprint: self.id,
         rooms: [],
         params: {},
         pendingActions: 0,

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -109,7 +109,6 @@ module.exports = {
         var id = uuid.v4();
         api.servers.servers.testServer.buildConnection({
           id             : id,
-          fingerprint    : id,
           rawConnection  : {},
           remoteAddress  : 'testServer',
           remotePort     : 0

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -109,6 +109,7 @@ module.exports = {
         var id = uuid.v4();
         api.servers.servers.testServer.buildConnection({
           id             : id,
+          fingerprint    : id,
           rawConnection  : {},
           remoteAddress  : 'testServer',
           remotePort     : 0

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ if(process.platform === 'win32'){
 }
 
 var mocha = __dirname + path.sep + 'node_modules' + path.sep + '.bin' + path.sep + execeutable;
-var child = spawn(mocha, ['test'], {
+var child = spawn(mocha, ['test', '--reporter', 'dot'], {
   cwd: __dirname,
   env: testEnv
 });

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -5,7 +5,6 @@ var actionhero = new actionheroPrototype();
 var api;
 
 var tmpPath = require('os').tmpdir() + require('path').sep + 'locale' + require('path').sep;
-console.log(tmpPath)
 
 var readLocaleFile = function(locale){
   if(!locale){ locale = api.config.i18n.defaultLocale; }

--- a/test/core/specHelper.js
+++ b/test/core/specHelper.js
@@ -108,6 +108,7 @@ describe('Core: specHelper', function(){
         response.messageCount.should.equal(1);
         connection.messages.length.should.equal(2);
         connId.should.equal(connection.id);
+        conn.fingerprint.should.equal(connId);
         done();
       });
     });
@@ -117,6 +118,16 @@ describe('Core: specHelper', function(){
         response.messageCount.should.equal(2);
         connection.messages.length.should.equal(3);
         connId.should.equal(connection.id);
+        conn.fingerprint.should.equal(connId);
+        done();
+      });
+    });
+
+    it('will generate new ids and fingerprints for a new connection', function(done){
+      api.specHelper.runAction('randomNumber', {}, function(response, connection){
+        response.messageCount.should.equal(1);
+        connection.id.should.not.equal(connId);
+        connection.fingerprint.should.not.equal(connId);
         done();
       });
     });

--- a/test/servers/socket.js
+++ b/test/servers/socket.js
@@ -125,6 +125,7 @@ describe('Server: Socket', function(){
       response.data.should.be.an.instanceOf(Object);
       response.data.params.should.be.an.instanceOf(Object);
       response.data.connectedAt.should.be.within(10, new Date().getTime());
+      response.data.id.should.equal(response.data.fingerprint);
       client2Details = response.data; // save for later!
       done();
     });


### PR DESCRIPTION
When creating a new `api.specHelper.connecton()`, the connection should be assigned a fingerprint which is the same as the connection's ID. 