### PR TITLE
Changed binary generator commands.

### DIFF
--- a/bin/actionhero
+++ b/bin/actionhero
@@ -155,6 +155,7 @@ if(process.env.actionheroRoot){
 binary.argv = require('optimist').argv;
 
 binary.actions = {};
+binary.deprecatedWarnings = [];
 
 fs.readdirSync(binary.actionheroRoot + '/bin/methods/').sort().forEach(function(file){
   if(file.indexOf('.js') > 0){

--- a/bin/actionhero
+++ b/bin/actionhero
@@ -155,7 +155,6 @@ if(process.env.actionheroRoot){
 binary.argv = require('optimist').argv;
 
 binary.actions = {};
-binary.deprecatedWarnings = [];
 
 fs.readdirSync(binary.actionheroRoot + '/bin/methods/').sort().forEach(function(file){
   if(file.indexOf('.js') > 0){

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -1,103 +1,131 @@
 'use strict';
 
 var fs = require('fs');
-
+var path = require('path');
 exports.generate = function(binary, next){
-
-  //////// DOCUMENTS ////////
-
-  var documents = {};
-
-  documents.projectMap = fs.readFileSync(binary.actionheroRoot + '/bin/templates/projectMap.txt');
-
-  var oldFileMap = {
-    configApiJs         : '/config/api.js',
-    configLoggerJs      : '/config/logger.js',
-    configRedisJs       : '/config/redis.js',
-    configTasksJs       : '/config/tasks.js',
-    configErrorsJs      : '/config/errors.js',
-    configI18nJs        : '/config/i18n.js',
-    configRoutesJs      : '/config/routes.js',
-    configSocketJs      : '/config/servers/socket.js',
-    configWebJs         : '/config/servers/web.js',
-    configWebsocketJs   : '/config/servers/websocket.js',
-    packageJson         : '/package.json',
-    actionStatus        : '/actions/status.js',
-    actionChatRoom      : '/actions/createChatRoom.js',
-    actionDocumentation : '/actions/showDocumentation.js',
-    publicIndex         : '/public/index.html',
-    publicChat          : '/public/chat.html',
-    publicLogo          : '/public/logo/actionhero.png',
-    publicSky           : '/public/logo/sky.jpg',
-    publicCss           : '/public/css/actionhero.css',
-    exampleTest         : '/test/template.js.example'
-  };
-  for(var name in oldFileMap){
-    documents[name] = fs.readFileSync(binary.actionheroRoot + oldFileMap[name]);
-  }
-
-  var AHversionNumber = JSON.parse(documents.packageJson).version;
-
-  documents.packageJson = String(fs.readFileSync(binary.actionheroRoot + '/bin/templates/package.json'));
-  documents.packageJson = documents.packageJson.replace('%%versionNumber%%', AHversionNumber);
-  documents.readmeMd    = String(fs.readFileSync(binary.actionheroRoot + '/bin/templates/README.md'));
-
   //////// LOGIC ////////
-
-  binary.log('Generating a new actionhero project...');
-
-  // make directories
-  [
-    '/actions',
-    '/pids',
-    '/config',
-    '/config/servers',
-    '/initializers',
-    '/log',
-    '/servers',
-    '/public',
-    '/public/javascript',
-    '/public/css',
-    '/public/logo',
-    '/tasks',
-    '/test'
-  ].forEach(function(dir){
-    binary.utils.createDirSafely(binary.projectRoot + dir);
+  binary.generator = {};
+  binary.generator.actions = [];
+  fs.readdirSync(binary.actionheroRoot + '/bin/methods/generators/').sort().forEach(function(file){
+    if(file.indexOf('.js') > 0){
+      var action = file.split('.')[0];
+      binary.generator.actions[action] = require(binary.actionheroRoot + '/bin/methods/generators/' + file)[action];
+    }
   });
 
-  // make files
-  var newFileMap = {
-    '/config/api.js'                                : 'configApiJs',
-    '/config/logger.js'                             : 'configLoggerJs',
-    '/config/redis.js'                              : 'configRedisJs',
-    '/config/tasks.js'                              : 'configTasksJs',
-    '/config/errors.js'                             : 'configErrorsJs',
-    '/config/i18n.js'                               : 'configI18nJs',
-    '/config/routes.js'                             : 'configRoutesJs',
-    '/config/servers/socket.js'                     : 'configSocketJs',
-    '/config/servers/web.js'                        : 'configWebJs',
-    '/config/servers/websocket.js'                  : 'configWebsocketJs',
-    '/package.json'                                 : 'packageJson',
-    '/actions/status.js'                            : 'actionStatus',
-    '/actions/createChatRoom.js'                    : 'actionChatRoom',
-    '/actions/showDocumentation.js'                 : 'actionDocumentation',
-    '/public/index.html'                            : 'publicIndex',
-    '/public/chat.html'                             : 'publicChat',
-    '/public/css/actionhero.css'                    : 'publicCss',
-    '/public/logo/actionhero.png'                   : 'publicLogo',
-    '/public/logo/sky.jpg'                          : 'publicSky',
-    '/README.md'                                    : 'readmeMd',
-    '/test/example.js'                              : 'exampleTest'
+  binary.generator.mainAction = binary.argv._[1];
+
+  var run = function(){
+    console.log('running', binary.generator.mainAction);
+    if(binary.actions[binary.mainAction] && binary.generator.actions[binary.generator.mainAction]){
+      binary.log('actionhero >> ' + binary.mainAction + ' ' + binary.generator.mainAction);
+      binary.log('project_root >> ' + path.normalize(binary.projectRoot), 'debug');
+      binary.log('actionheroRoot >> ' + path.normalize(binary.actionheroRoot), 'debug');
+      binary.generator.actions[binary.generator.mainAction](binary, function(toStop){
+        if(toStop === true){ process.exit(); }
+      });
+    }else{
+      binary.actions.unknownInput(binary, function(){});
+      process.exit(1);
+    }
   };
-  for(var file in newFileMap){
-    binary.utils.createFileSafely(binary.projectRoot + file, documents[newFileMap[file]]);
+
+  if(!binary.generator.mainAction || typeof binary.generator.actions[binary.generator.mainAction] !== 'function') {
+    //////// DOCUMENTS ////////
+    console.log('bin actions', typeof binary.generator.actions[binary.generator.mainAction]);
+    var documents = {};
+
+    documents.projectMap = fs.readFileSync(binary.actionheroRoot + '/bin/templates/projectMap.txt');
+
+    var oldFileMap = {
+      configApiJs         : '/config/api.js',
+      configLoggerJs      : '/config/logger.js',
+      configRedisJs       : '/config/redis.js',
+      configTasksJs       : '/config/tasks.js',
+      configErrorsJs      : '/config/errors.js',
+      configI18nJs        : '/config/i18n.js',
+      configRoutesJs      : '/config/routes.js',
+      configSocketJs      : '/config/servers/socket.js',
+      configWebJs         : '/config/servers/web.js',
+      configWebsocketJs   : '/config/servers/websocket.js',
+      packageJson         : '/package.json',
+      actionStatus        : '/actions/status.js',
+      actionChatRoom      : '/actions/createChatRoom.js',
+      actionDocumentation : '/actions/showDocumentation.js',
+      publicIndex         : '/public/index.html',
+      publicChat          : '/public/chat.html',
+      publicLogo          : '/public/logo/actionhero.png',
+      publicSky           : '/public/logo/sky.jpg',
+      publicCss           : '/public/css/actionhero.css',
+      exampleTest         : '/test/template.js.example'
+    };
+    for(var name in oldFileMap){
+      documents[name] = fs.readFileSync(binary.actionheroRoot + oldFileMap[name]);
+    }
+
+    var AHversionNumber = JSON.parse(documents.packageJson).version;
+
+    documents.packageJson = String(fs.readFileSync(binary.actionheroRoot + '/bin/templates/package.json'));
+    documents.packageJson = documents.packageJson.replace('%%versionNumber%%', AHversionNumber);
+    documents.readmeMd    = String(fs.readFileSync(binary.actionheroRoot + '/bin/templates/README.md'));
+
+    binary.log('Generating a new actionhero project...');
+
+    // make directories
+    [
+      '/actions',
+      '/pids',
+      '/config',
+      '/config/servers',
+      '/initializers',
+      '/log',
+      '/servers',
+      '/public',
+      '/public/javascript',
+      '/public/css',
+      '/public/logo',
+      '/tasks',
+      '/test'
+    ].forEach(function(dir){
+      binary.utils.createDirSafely(binary.projectRoot + dir);
+    });
+
+    // make files
+    var newFileMap = {
+      '/config/api.js'                                : 'configApiJs',
+      '/config/logger.js'                             : 'configLoggerJs',
+      '/config/redis.js'                              : 'configRedisJs',
+      '/config/tasks.js'                              : 'configTasksJs',
+      '/config/errors.js'                             : 'configErrorsJs',
+      '/config/i18n.js'                               : 'configI18nJs',
+      '/config/routes.js'                             : 'configRoutesJs',
+      '/config/servers/socket.js'                     : 'configSocketJs',
+      '/config/servers/web.js'                        : 'configWebJs',
+      '/config/servers/websocket.js'                  : 'configWebsocketJs',
+      '/package.json'                                 : 'packageJson',
+      '/actions/status.js'                            : 'actionStatus',
+      '/actions/createChatRoom.js'                    : 'actionChatRoom',
+      '/actions/showDocumentation.js'                 : 'actionDocumentation',
+      '/public/index.html'                            : 'publicIndex',
+      '/public/chat.html'                             : 'publicChat',
+      '/public/css/actionhero.css'                    : 'publicCss',
+      '/public/logo/actionhero.png'                   : 'publicLogo',
+      '/public/logo/sky.jpg'                          : 'publicSky',
+      '/README.md'                                    : 'readmeMd',
+      '/test/example.js'                              : 'exampleTest'
+    };
+    for(var file in newFileMap){
+      binary.utils.createFileSafely(binary.projectRoot + file, documents[newFileMap[file]]);
+    }
+
+    binary.log('');
+    binary.log('Generation Complete.  Your project directory should look like this:\n' + documents.projectMap);
+    binary.log('');
+    binary.log('you may need to run `npm install` to install some dependancies', 'alert');
+    binary.log('run \'npm start\' to start your server');
+
+    next(true);
+  }else{
+    run();
   }
-
-  binary.log('');
-  binary.log('Generation Complete.  Your project directory should look like this:\n' + documents.projectMap);
-  binary.log('');
-  binary.log('you may need to run `npm install` to install some dependancies', 'alert');
-  binary.log('run \'npm start\' to start your server');
-
-  next(true);
 };

--- a/bin/methods/generators/action.js
+++ b/bin/methods/generators/action.js
@@ -4,7 +4,8 @@ var fs = require('fs');
 
 exports.action = function(binary, next){
   if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
-  if(!binary.argv.description){ binary.argv.description = binary.argv.name; }
+  var name = !binary.argv.name ? binary.argv._[2] : binary.argv.name;
+  if(!binary.argv.description){ binary.argv.description = name; }
 
   var data = fs.readFileSync(binary.actionheroRoot + '/bin/templates/action.js');
   data = String(data);
@@ -14,10 +15,13 @@ exports.action = function(binary, next){
     'description',
   ].forEach(function(v){
     var regex = new RegExp('%%' + v + '%%', 'g');
+    if (v === 'name'){
+      data = data.replace(regex, name);
+    }
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.action[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.action[0] + '/' + name + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/action.js
+++ b/bin/methods/generators/action.js
@@ -2,9 +2,8 @@
 
 var fs = require('fs');
 
-exports.generateAction = function(binary, next){
-
-  if(!binary.argv.name){ binary.utils.hardError('name is a required input'); }
+exports.action = function(binary, next){
+  if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
   if(!binary.argv.description){ binary.argv.description = binary.argv.name; }
 
   var data = fs.readFileSync(binary.actionheroRoot + '/bin/templates/action.js');
@@ -18,7 +17,7 @@ exports.generateAction = function(binary, next){
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.action[0] + '/' + binary.argv.name + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.action[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/initializer.js
+++ b/bin/methods/generators/initializer.js
@@ -2,9 +2,9 @@
 
 var fs = require('fs');
 
-exports.generateInitializer = function(binary, next){
+exports.initializer = function(binary, next){
 
-  if(!binary.argv.name){ binary.utils.hardError('name is a required input'); }
+  if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
 
   var data = fs.readFileSync(binary.actionheroRoot + '/bin/templates/initializer.js');
   data = String(data);
@@ -16,7 +16,7 @@ exports.generateInitializer = function(binary, next){
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.initializer[0] + '/' + binary.argv.name + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.initializer[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/initializer.js
+++ b/bin/methods/generators/initializer.js
@@ -6,6 +6,7 @@ exports.initializer = function(binary, next){
 
   if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
 
+  var name = !binary.argv.name ? binary.argv._[2] : binary.argv.name;
   var data = fs.readFileSync(binary.actionheroRoot + '/bin/templates/initializer.js');
   data = String(data);
 
@@ -13,10 +14,13 @@ exports.initializer = function(binary, next){
     'name',
   ].forEach(function(v){
     var regex = new RegExp('%%' + v + '%%', 'g');
+    if (v === 'name'){
+      data = data.replace(regex, name);
+    }
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.initializer[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.initializer[0] + '/' + name + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/server.js
+++ b/bin/methods/generators/server.js
@@ -2,9 +2,9 @@
 
 var fs = require('fs');
 
-exports.generateServer = function(binary, next){
+exports.server = function(binary, next){
 
-  if(!binary.argv.name){ binary.utils.hardError('name is a required input'); }
+  if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
 
   var data = fs.readFileSync(binary.actionheroRoot + '/bin/templates/server.js');
   data = String(data);
@@ -16,7 +16,7 @@ exports.generateServer = function(binary, next){
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.server[0] + '/' + binary.argv.name + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.server[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/server.js
+++ b/bin/methods/generators/server.js
@@ -6,6 +6,7 @@ exports.server = function(binary, next){
 
   if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
 
+  var name = !binary.argv.name ? binary.argv._[2] : binary.argv.name;
   var data = fs.readFileSync(binary.actionheroRoot + '/bin/templates/server.js');
   data = String(data);
 
@@ -13,10 +14,13 @@ exports.server = function(binary, next){
     'name',
   ].forEach(function(v){
     var regex = new RegExp('%%' + v + '%%', 'g');
+    if (v === 'name'){
+      data = data.replace(regex, name);
+    }
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.server[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.server[0] + '/' + name + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/task.js
+++ b/bin/methods/generators/task.js
@@ -5,7 +5,8 @@ var fs = require('fs');
 exports.task = function(binary, next){
 
   if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
-  if(!binary.argv.description){ binary.argv.description = binary.argv.name; }
+  var name = !binary.argv.name ? binary.argv._[2] : binary.argv.name;
+  if(!binary.argv.description){ binary.argv.description = name; }
   if(!binary.argv.queue){ binary.argv.queue = 'default'; }
   if(!binary.argv.frequency){ binary.argv.frequency = 0; }
 
@@ -19,10 +20,13 @@ exports.task = function(binary, next){
     'frequency',
   ].forEach(function(v){
     var regex = new RegExp('%%' + v + '%%', 'g');
+    if (v === 'name'){
+      data = data.replace(regex, name);
+    }
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.task[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.task[0] + '/' + name + '.js', data);
 
   next(true);
 };

--- a/bin/methods/generators/task.js
+++ b/bin/methods/generators/task.js
@@ -2,9 +2,9 @@
 
 var fs = require('fs');
 
-exports.generateTask = function(binary, next){
+exports.task = function(binary, next){
 
-  if(!binary.argv.name){ binary.utils.hardError('name is a required input'); }
+  if(!binary.argv.name && !binary.argv._[2]){ binary.utils.hardError('name is a required input'); }
   if(!binary.argv.description){ binary.argv.description = binary.argv.name; }
   if(!binary.argv.queue){ binary.argv.queue = 'default'; }
   if(!binary.argv.frequency){ binary.argv.frequency = 0; }
@@ -22,7 +22,7 @@ exports.generateTask = function(binary, next){
     data = data.replace(regex, binary.argv[v]);
   });
 
-  binary.utils.createFileSafely(binary.config.general.paths.task[0] + '/' + binary.argv.name + '.js', data);
+  binary.utils.createFileSafely(binary.config.general.paths.task[0] + '/' + (!binary.argv.name ? binary.argv._[2] : binary.argv.name) + '.js', data);
 
   next(true);
 };

--- a/bin/methods/unknownInput.js
+++ b/bin/methods/unknownInput.js
@@ -2,6 +2,25 @@
 
 exports.unknownInput = function(binary, next){
   binary.log('\'' + binary.mainAction + '\' is not a known action', 'warning');
+
+  // TODO: Delete these deprecated warnings in next major actionhero version (v16)
+  if(binary.mainAction == 'generateAction'){
+    binary.log('`actionhero generateAction` command no longer in use.', 'warning');
+    binary.log('use `actionhero generate action <name>` instead.', 'warning');
+  }
+  if(binary.mainAction == 'generateInitializer'){
+    binary.log('`actionhero generateInitializer` command no longer in use.', 'warning');
+    binary.log('use `actionhero generate initializer <name>` instead.', 'warning');
+  }
+  if(binary.mainAction == 'generateServer'){
+    binary.log('`actionhero generateServer` command no longer in use.', 'warning');
+    binary.log('use `actionhero generate server <name>` instead.', 'warning');
+  }
+  if(binary.mainAction == 'generateTask'){
+    binary.log('`actionhero generateTask` command no longer in use.', 'warning');
+    binary.log('use `actionhero generate task <name>` instead.', 'warning');
+  }
+
   binary.log('run \'actionhero help\' for more information', 'warning');
   next(true);
 };

--- a/bin/templates/help.txt
+++ b/bin/templates/help.txt
@@ -42,13 +42,13 @@ Descriptions:
 * actionhero generate
   will prepare an empty directory with a template actionhero project
 
-* actionhero generateAction --name=[name] --description=[description]
+* actionhero generate action <name> --description=[description]
     --inputsRequired=[inputsRequired] --inputsOptional=[inputsOptional]
   will generate a new action in "actions"
   [name] (required)
   [description] (required) should be wrapped in quotes if it contains spaces
 
-* actionhero generateTask --name=[name] --description=[description]
+* actionhero generate task <name> --description=[description]
     --scope=[scope] --frequency=[frequency]
   will generate a new task in "tasks"
   [name] (required)
@@ -56,11 +56,11 @@ Descriptions:
   [scope] (optional) can be "any" or "all"
   [frequency] (optional)
 
-* actionhero generateInitializer --name=[name]
+* actionhero generate initializer <name>
   will generate a new initializer in "initializers"
   [name] (required)
 
-* actionhero generateServer --name=[name]
+* actionhero generate server <name>
   will generate a new server in "servers"
   [name] (required)
 
@@ -81,7 +81,7 @@ Descriptions:
 
 * actionhero unlink --name=[pluginName]
   will remove the linked actions, tasks, initializers, etc from a plugin in your
-    top-level project. Please remove the config files manually  
+    top-level project. Please remove the config files manually
   Remember if your plugin was installed via NPM, also be sure to remove it from your
     package.json or uninstall it with npm uninstall --save
 

--- a/test/core/binary.js
+++ b/test/core/binary.js
@@ -113,7 +113,7 @@ describe('Core: Binary', function(){
         should.not.exist(error);
         data.should.containEql('actionhero startCluster');
         data.should.containEql('Binary options:');
-        data.should.containEql('actionhero generateServer');
+        data.should.containEql('actionhero generate server');
         done();
       });
     });
@@ -133,7 +133,7 @@ describe('Core: Binary', function(){
     it('can generate an action', function(done){
       doBash([
         'cd ' + testDir,
-        binary + ' generateAction --name=myAction --description=my_description'
+        binary + ' generate action myAction --description=my_description'
       ], function(error){
         should.not.exist(error);
         var data = String(fs.readFileSync(testDir + '/actions/myAction.js'));
@@ -147,7 +147,7 @@ describe('Core: Binary', function(){
     it('can generate a task', function(done){
       doBash([
         'cd ' + testDir,
-        binary + ' generateTask --name=myTask --description=my_description --queue=my_queue --frequency=12345'
+        binary + ' generate task myTask --description=my_description --queue=my_queue --frequency=12345'
       ], function(error){
         should.not.exist(error);
         var data = String(fs.readFileSync(testDir + '/tasks/myTask.js'));
@@ -163,7 +163,7 @@ describe('Core: Binary', function(){
     it('can generate a server', function(done){
       doBash([
         'cd ' + testDir,
-        binary + ' generateServer --name=myServer'
+        binary + ' generate server myServer'
       ], function(error){
         should.not.exist(error);
         var data = String(fs.readFileSync(testDir + '/servers/myServer.js'));
@@ -178,7 +178,7 @@ describe('Core: Binary', function(){
     it('can generate a initializer', function(done){
       doBash([
         'cd ' + testDir,
-        binary + ' generateInitializer --name=myInitializer'
+        binary + ' generate initializer myInitializer'
       ], function(error){
         should.not.exist(error);
         var data = String(fs.readFileSync(testDir + '/initializers/myInitializer.js'));


### PR DESCRIPTION
This pull request changes the following commands:

```
`actionhero generateAction --name=[name]`      -> `actionhero generate action <name>` 
`actionhero generateInitializer --name=[name]` -> `actionhero generate initializer <name>` 
`actionhero generateServer --name=[name]`      -> `actionhero generate server <name>` 
`actionhero generateTask --name=[name]`        -> `actionhero generate task <name>` 
```

You can also still use `--name` option like this `generate task --name=MyCoolTask`