### PR TITLE
no callback for api.tasks.addMiddleware

### DIFF
--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -341,8 +341,8 @@ module.exports = {
       });
     }
 
-    api.tasks.addMiddleware = function(middleware, callback){
-      if(!middleware.name){ return callback(new Error('middleware.name is required')); }
+    api.tasks.addMiddleware = function(middleware){
+      if(!middleware.name){ throw new Error('middleware.name is required'); }
       if(!middleware.priority){ middleware.priority = api.config.general.defaultMiddlewarePriority; }
       middleware.priority = Number(middleware.priority);
       api.tasks.middleware[middleware.name] = middleware;
@@ -351,7 +351,6 @@ module.exports = {
         api.utils.sortGlobalMiddleware(api.tasks.globalMiddleware, api.tasks.middleware);
       }
       loadTasks(true);
-      callback();
     };
 
     loadTasks(false);

--- a/site/source/includes/docs/core/middleware.md
+++ b/site/source/includes/docs/core/middleware.md
@@ -234,9 +234,7 @@ module.exports = {
       }
     };
 
-    api.tasks.addMiddleware(api.taskTimer.middleware, function(error){
-      next(error);
-    });
+    api.tasks.addMiddleware(api.taskTimer.middleware);
   }
 };
 ```

--- a/test/tasks/middleware.js
+++ b/test/tasks/middleware.js
@@ -51,23 +51,23 @@ describe('Test: Task Middleware', function(){
     actionhero.start(function(error, a){
       api = a;
 
-      api.tasks.addMiddleware(middleware, function(error){
-        api.tasks.tasks.middlewareTask = {
-          name: 'middlewareTask',
-          description: 'middlewaretask',
-          queue: 'default',
-          frequency: 0,
-          middleware: ['test-middleware'],
-          run: function(api, params, next){
-            params.test.should.exist;
-            next(null, {result: 'done'});
-          }
-        };
+      api.tasks.addMiddleware(middleware);
 
-        api.tasks.jobs.middlewareTask = api.tasks.jobWrapper('middlewareTask');
+      api.tasks.tasks.middlewareTask = {
+        name: 'middlewareTask',
+        description: 'middlewaretask',
+        queue: 'default',
+        frequency: 0,
+        middleware: ['test-middleware'],
+        run: function(api, params, next){
+          params.test.should.exist;
+          next(null, {result: 'done'});
+        }
+      };
 
-        done(error);
-      });
+      api.tasks.jobs.middlewareTask = api.tasks.jobWrapper('middlewareTask');
+
+      done(error);
     });
   });
 


### PR DESCRIPTION
It's not needed as there is nothing async here; and this will better match all other addMiddleware signatures. 