### PR TITLE
simply calling of api.commands

### DIFF
--- a/actionhero.js
+++ b/actionhero.js
@@ -64,10 +64,10 @@ actionhero.prototype.initialize = function(params, callback){
 
   self.api._self = self;
   self.api.commands = {
-    initialize: self.initialize,
-    start: self.start,
-    stop: self.stop,
-    restart: self.restart
+    initialize: function(params, callback){ self.initialize.call(self, params, callback); },
+    start:      function(params, callback){ self.start.call(self, params, callback); },
+    stop:       function(callback){ self.stop.call(self, callback); },
+    restart:    function(callback){ self.restart.call(self, callback); }
   };
 
   self.api.projectRoot = process.cwd();
@@ -140,7 +140,7 @@ actionhero.prototype.initialize = function(params, callback){
         var loadFunction = function(next){
           self.api.watchFileAndAct(file, function(){
             self.api.log(['*** Rebooting due to initializer change (%s) ***', file], 'info');
-            self.api.commands.restart.call(self.api._self);
+            self.api.commands.restart();
           });
 
           if(typeof self.initializers[initializer].initialize === 'function'){

--- a/initializers/config.js
+++ b/initializers/config.js
@@ -104,7 +104,7 @@ module.exports = {
     var rebootCallback = function(file){
       api.log(['*** rebooting due to config change (%s) ***', file], 'info');
       delete require.cache[require.resolve(file)];
-      api.commands.restart.call(api._self);
+      api.commands.restart();
     };
 
     api.loadConfigDirectory = function(configPath, watch){

--- a/initializers/servers.js
+++ b/initializers/servers.js
@@ -44,7 +44,7 @@ module.exports = {
         }
         api.watchFileAndAct(f, function(){
           api.log(['*** Rebooting due to server (%s) change ***', serverName], 'info');
-          api.commands.restart.call(api._self);
+          api.commands.restart();
         });
       });
     });

--- a/site/source/includes/docs/core/development_mode.md
+++ b/site/source/includes/docs/core/development_mode.md
@@ -30,7 +30,7 @@ Development mode, when enabled, will poll for changes in your actions, tasks and
 ```javascript
 api.watchFileAndAct(path_to_file, function(){
   api.log('rebooting due to config change: ' + path_to_file, 'info');
-  api.commands.restart.call(api._self);
+  api.commands.restart();
 });
 ```
 


### PR DESCRIPTION
Passing scope into `api.commands.start()`/`stop`/`restart` is dumb.  Lets simplify this! 

Solves https://github.com/evantahler/actionhero/issues/927