### PR TITLE
Provide a different initial backoff for ioredis connections that may be misconfigured or not yet available

### DIFF
--- a/config/redis.js
+++ b/config/redis.js
@@ -2,6 +2,7 @@ var host     = process.env.REDIS_HOST || '127.0.0.1';
 var port     = process.env.REDIS_PORT || 6379;
 var db       = process.env.REDIS_DB   || 0;
 var password = process.env.REDIS_PASS || null;
+var maxBackoff = 1000;
 
 exports['default'] = {
   redis: function(api){
@@ -12,21 +13,30 @@ exports['default'] = {
 
     if(process.env.FAKEREDIS === 'false' || process.env.REDIS_HOST !== undefined){
 
+      function retryStrategy(times) {
+        if (times === 1) {
+          api.log('Unable to connect to Redis - please check your Redis config!', 'error');
+          return 5000;
+        }
+
+        return Math.min(times * 50, maxBackoff);
+      }
+
       return {
         '_toExpand': false,
         client: {
           konstructor: require('ioredis'),
-          args: [{ port: port, host: host, password: password, db: db }],
+          args: [{ port: port, host: host, password: password, db: db, retryStrategy: retryStrategy }],
           buildNew: true
         },
         subscriber: {
           konstructor: require('ioredis'),
-          args: [{ port: port, host: host, password: password, db: db }],
+          args: [{ port: port, host: host, password: password, db: db, retryStrategy: retryStrategy }],
           buildNew: true
         },
         tasks: {
           konstructor: require('ioredis'),
-          args: [{ port: port, host: host, password: password, db: db }],
+          args: [{ port: port, host: host, password: password, db: db, retryStrategy: retryStrategy }],
           buildNew: true
         }
       };


### PR DESCRIPTION
Users with a misconfigured `ioredis` config, or those running Docker containers where the Redis service may not yet be fully started, may see heavy log spam during AH's boot cycle. The default `ioredis` configuration auto-reconnects every 50ms and can rapidly exhaust a log before an admin sees what's going on.

This PR does two things:

1. It provides a staged back-off interval for reconnection attempts up to a maximum, currently set at a low, safe 1 second.

1. It provides a much longer reconnection delay for the FIRST attempt, with a convenience message for the admin:

```
2016-08-23T15:50:41.378Z - notice: * Starting ActionHero *
>> 2016-08-23T15:50:41.389Z - error: Redis connection `client` error Error: connect ECONNREFUSED 127.0.0.1:6379
>>     at Object.exports._errnoException (util.js:870:11)
>>     at exports._exceptionWithHostPort (util.js:893:20)
>>     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1063:14)
>> 2016-08-23T15:50:41.390Z - error: Unable to connect to Redis - please check your Redis config!
```

This is particularly handy for developers working locally, giving them time to break out and reconfigure before spamming them with connection failure messages (which, in dev, get printed to the console).

A caveat: `ioredis` provides the `times` parameter as the number of times reconnects have been attempted since the last successful connection, or since program start. This means after a successful connection, the counter resets and will trigger the longer delay for the first reconnection attempt. This doesn't break AH because core already has a `api.redis.clients[r].once('connect', done);` employed to block start-completion of the Redis module until the first successful connection.

I personally do not believe this is a problem, because in practice, production Redis disconnects are exceedingly rare outside of actual server failure. In nearly all environments, Redis tends to be collocated on or "near" (ElastiCache) the client host. The only condition where an immediate-reconnect is likely to be successful in the first place is a transient network issue. I haven't seen one of these in two years of using AH at Firetalk and News Rush. In a server failure, a longer reconnect makes sense and many systems deliberately employ this.

That said, if this behavior is not desirable it would be possible to enhance this PR either by:

1. Altering the `self.initializers[initializer].start` callback to set a `started = true` flag on each initializer. Since the Redis initializer blocks start until the first connection is made, the `retryStrategy` function could check `if (!api.redis.started) {...}` to gate this behavior. This is more global but could be a handy pattern for other use-cases in the future.

1. Adding a flag in the Redis initializer itself in the `on('connect')` handler. This is more local if #1 is not desirable.