### PR TITLE
Fix ETAG issue for files

### DIFF
--- a/servers/web.js
+++ b/servers/web.js
@@ -114,42 +114,54 @@ var initialize = function(api, options, next){
     if(error){ connection.rawConnection.responseHttpCode = 404; }
     if(ifModifiedSince && lastModified <= ifModifiedSince){ connection.rawConnection.responseHttpCode = 304; }
     if(api.config.servers.web.enableEtag && fileStream){
-      var filestats = fs.statSync(fileStream.path);
-      var fileEtag = etag(filestats, {weak: true});
-      connection.rawConnection.responseHeaders.push(['ETag', fileEtag]);
-      var noneMatchHeader = reqHeaders['if-none-match'];
-      var cacheCtrlHeader = reqHeaders['cache-control'];
-      var noCache = false;
-      var etagMatches;
-      // check for no-cache cache request directive
-      if(cacheCtrlHeader && cacheCtrlHeader.indexOf('no-cache') !== -1){
-        noCache = true;
-      }
+      fs.stat(fileStream.path, function(error, filestats){
+        var fileEtag = etag(filestats, {weak: true});
+        connection.rawConnection.responseHeaders.push(['ETag', fileEtag]);
+        var noneMatchHeader = reqHeaders['if-none-match'];
+        var cacheCtrlHeader = reqHeaders['cache-control'];
+        var noCache = false;
+        var etagMatches;
+        // check for no-cache cache request directive
+        if(cacheCtrlHeader && cacheCtrlHeader.indexOf('no-cache') !== -1){
+          noCache = true;
+        }
 
-      // parse if-none-match
-      if(noneMatchHeader){ noneMatchHeader = noneMatchHeader.split(/ *, */); }
+        // parse if-none-match
+        if(noneMatchHeader){ noneMatchHeader = noneMatchHeader.split(/ *, */); }
 
-      // if-none-match
-      if(noneMatchHeader){
-        etagMatches = noneMatchHeader.some(function(match){
-          return match === '*' || match === fileEtag || match === 'W/' + fileEtag;
-        });
-      }
+        // if-none-match
+        if(noneMatchHeader){
+          etagMatches = noneMatchHeader.some(function(match){
+            return match === '*' || match === fileEtag || match === 'W/' + fileEtag;
+          });
+        }
 
-      if(etagMatches && !noCache){
-        connection.rawConnection.responseHttpCode = 304;
+        if(etagMatches && !noCache){
+          connection.rawConnection.responseHttpCode = 304;
+        }
+        var responseHttpCode = parseInt(connection.rawConnection.responseHttpCode);
+        if(error){
+          server.sendWithCompression(connection, responseHttpCode, headers, String(error));
+        }else if(responseHttpCode !== 304){
+          server.sendWithCompression(connection, responseHttpCode, headers, null, fileStream, length);
+        }else{
+          connection.rawConnection.res.writeHead(responseHttpCode, headers);
+          connection.rawConnection.res.end();
+          connection.destroy();
+        }
+      });
+    } else {
+      var responseHttpCode = parseInt(connection.rawConnection.responseHttpCode);
+      if(error){
+        server.sendWithCompression(connection, responseHttpCode, headers, String(error));
       }
-    }
-    var responseHttpCode = parseInt(connection.rawConnection.responseHttpCode);
-    if(error){
-      server.sendWithCompression(connection, responseHttpCode, headers, String(error));
-    }
-    else if(responseHttpCode !== 304){
-      server.sendWithCompression(connection, responseHttpCode, headers, null, fileStream, length);
-    }else{
-      connection.rawConnection.res.writeHead(responseHttpCode, headers);
-      connection.rawConnection.res.end();
-      connection.destroy();
+      else if(responseHttpCode !== 304){
+        server.sendWithCompression(connection, responseHttpCode, headers, null, fileStream, length);
+      }else{
+        connection.rawConnection.res.writeHead(responseHttpCode, headers);
+        connection.rawConnection.res.end();
+        connection.destroy();
+      }
     }
   };
 

--- a/servers/web.js
+++ b/servers/web.js
@@ -114,8 +114,8 @@ var initialize = function(api, options, next){
     if(error){ connection.rawConnection.responseHttpCode = 404; }
     if(ifModifiedSince && lastModified <= ifModifiedSince){ connection.rawConnection.responseHttpCode = 304; }
     if(api.config.servers.web.enableEtag && fileStream){
-      var fileBuffer = !Buffer.isBuffer(fileStream) ? new Buffer(fileStream.toString(), 'utf8') : fileStream;
-      var fileEtag = etag(fileBuffer, {weak: true});
+      var filestats = fs.statSync(fileStream.path);
+      var fileEtag = etag(filestats, {weak: true});
       connection.rawConnection.responseHeaders.push(['ETag', fileEtag]);
       var noneMatchHeader = reqHeaders['if-none-match'];
       var cacheCtrlHeader = reqHeaders['cache-control'];

--- a/test/core/staticFile.js
+++ b/test/core/staticFile.js
@@ -94,6 +94,23 @@ describe('Core: Static File', function(){
     });
   });
 
+
+  it('should send a different etag for other files', function(done){
+    request.get(url + '/simple.html', function(error, response){
+      response.statusCode.should.equal(200);
+      should.exist(response.headers['etag']);
+      var etagSimple = response.headers['etag'];
+      request.get(url + '/index.html', function(error, response){
+        response.statusCode.should.equal(200);
+        should.exist(response.headers['etag']);
+        var etagIndex = response.headers['etag'];
+        should.notEqual(etagIndex, etagSimple);
+        done();
+      });
+
+    });
+  });
+
   it('should send back the file if the header "if-modified-since" is present but condition does not match', function(done){
     request.get(url + '/simple.html', function(error, response, body){
       response.statusCode.should.eql(200);


### PR DESCRIPTION
We've found a issue with the etags, every file had the same etag. This was because fileStream.toString() is [object Object] and not the content istself. So every ETAG was generated for [object Object]

I've added a test to check if the ETAG is NOT the same for different files.