### PR TITLE
fix no workerTitlePrefix then show NaN title

### DIFF
--- a/bin/methods/start/cluster.js
+++ b/bin/methods/start/cluster.js
@@ -404,9 +404,9 @@ module.exports = function(api){
 
       var title = optimist.argv.workerTitlePrefix
       
-      if(title == null || title == '')
+      if(title === null || title === '')
         title = 'actionhero-worker-';
-      else if(title == 'hostname')
+      else if(title === 'hostname')
         title = os.hostname() + '-';
 
       title += workerId;

--- a/bin/methods/start/cluster.js
+++ b/bin/methods/start/cluster.js
@@ -404,7 +404,9 @@ module.exports = function(api){
 
       var title = optimist.argv.workerTitlePrefix
       
-      if(title == 'hostname')
+      if(title == null || title == '')
+        title = 'actionhero-worker-';
+      else if(title == 'hostname')
         title = os.hostname() + '-';
 
       title += workerId;


### PR DESCRIPTION
fix a little bug.

I had assigned `.default('workerTitlePrefix', 'actionhero-worker-')`, but look no use.
So I add some code to fix that issue.