### PR TITLE
Updates error string formatting

### DIFF
--- a/initializers/utils.js
+++ b/initializers/utils.js
@@ -130,7 +130,7 @@ module.exports = {
                   try{
                     api.log(['cannot find linked refrence to `%s`', file], 'warning');
                   }catch(e){
-                    throw('cannot find linked refrence to' + file);
+                    throw('cannot find linked refrence to ' + file);
                   }
                 }
               }


### PR DESCRIPTION
I misnamed a plugin reference, and an error had me temporarily confused.

"cannot find linked refrence toah-sequelize.plugin.link "

This fix would format the error as -
"cannot find linked refrence to ah-sequelize.plugin.link"