### PR TITLE
Fix cache headers

### DIFF
--- a/config/servers/web.js
+++ b/config/servers/web.js
@@ -37,8 +37,12 @@ exports['default'] = {
         simpleRouting : true,
         // queryRouting allows an action to be defined via a URL param, ie: /api?action=:action
         queryRouting : true,
-        // The header which will be returned for all flat file served from /public; defined in seconds
+        // The cache or (if etags are enabled) next-revalidation time to be returned for all flat files served from /public; defined in seconds
         flatFileCacheDuration : 60,
+        // Add an etag header to requested flat files which acts as fingerprint that changes when the file is updated;
+        // Client will revalidate the fingerprint at latest after flatFileCacheDuration and reload it if the etag (and therfore the file) changed
+        // or continue to use the cached file if it's still valid
+        enableEtag: true,
         // How many times should we try to boot the server?
         // This might happen if the port is in use by another process or the socketfile is claimed
         bootAttempts: 1,
@@ -75,9 +79,7 @@ exports['default'] = {
         compress: false,
         // options to pass to the query parser
         // learn more about the options @ https://github.com/hapijs/qs
-        queryParseOptions: {},
-        // when true, an ETAG Header will be provided with each requested static file for caching reasons
-        enableEtag: true
+        queryParseOptions: {}
       };
     }
   }

--- a/servers/web.js
+++ b/servers/web.js
@@ -107,7 +107,6 @@ const initialize = function(api, options, next){
       if(!foundCacheControl){ connection.rawConnection.responseHeaders.push(['Cache-Control', 'max-age=' + api.config.servers.web.flatFileCacheDuration + ', must-revalidate, public']); }
     }
     if(fileStream && !api.config.servers.web.enableEtag){
-      if(!foundExpires){ connection.rawConnection.responseHeaders.push(['Expires', new Date(new Date().getTime() + api.config.servers.web.flatFileCacheDuration * 1000).toUTCString()]); }
       if(lastModified){ connection.rawConnection.responseHeaders.push(['Last-Modified', new Date(lastModified).toUTCString()]); }
     }
 
@@ -130,6 +129,7 @@ const initialize = function(api, options, next){
 
     if(reqHeaders['if-modified-since']){
       ifModifiedSince = new Date(reqHeaders['if-modified-since']);
+      lastModified.setMilliseconds(0);
       if(lastModified <= ifModifiedSince){connection.rawConnection.responseHttpCode = 304; }
       return sendRequestResult();
     }

--- a/site/source/includes/docs/core/file_server.md
+++ b/site/source/includes/docs/core/file_server.md
@@ -41,7 +41,7 @@ On .nix operating system's symlinks for both files and folders will be followed.
 
 ## Web Clients
 
-- `Cache-Control` and `Expires` headers will be sent, as defined by `api.config.commonWeb.flatFileCacheDuration`
+- `Cache-Control` and `Expires` or respectively `ETag` headers (depending on configuration) will be sent with it's caching or revalidation time defined by `api.config.servers.web.flatFileCacheDuration`
 - Content-Types for files will attempt to be determined using the [mime package](https://npmjs.org/package/mime)
 - web clients may request `connection.params.file` directly within an action which makes use of  `api.sendFile`, or if they are  under the `api.config.servers.web.urlPathForFiles` route, the file will be looked up as if the route matches the directory structure under `flatFileDirectory`.
 - if your action wants to send content down to a client directly, you will do so like this `server.sendFile(connection, null, stream, 'text/html', length);`

--- a/test/core/staticFile.js
+++ b/test/core/staticFile.js
@@ -54,10 +54,18 @@ describe('Core: Static File', function(){
     });
   });
 
-  it('should send back the last modified time', function(done){
+  it('should send back the cache-control header', function(done){
     request.get(url + '/simple.html', function(error, response, body){
       response.statusCode.should.eql(200);
-      response.headers['last-modified'].should.be.ok;
+      response.headers['cache-control'].should.be.ok;
+      done();
+    });
+  });
+
+  it('should send back the etag header', function(done){
+    request.get(url + '/simple.html', function(error, response, body){
+      response.statusCode.should.eql(200);
+      response.headers['etag'].should.be.ok;
       done();
     });
   });


### PR DESCRIPTION
With this push, no expires or last-modified headers are being sent when etags are enabled. Last-modified and etags are both 'weak' caching headers and we should opt for one; if the developer enabled etags we should make sure they are being used - but atm we let the clients browser implementation decide.

Additionally expires headers won't even be set with etags disabled, as the cache-control header supersedes the 'outdated' expires header - it is replaced by cache-control; both are 'strong' caching headers, we should opt for the newer one, even if it isn't new at all by now.

The current implementation wasn't working right, especially on mobile devices, with files getting cached longer than they should or not at all, depending on the platform.

Caching was a bit of a mess, i refactored the sendFile flow a bit and repaired if-modified-since requests. When a browser receives a page with a last-modified header, it may send the date received with the if-modified-since header, expecting a 304 if it didn't change. But nearly all of these requests will result in the file being sent even if unchanged as the milliseconds of the 'lastModified' (mTime) may differ from zero while the time string from browser (bTime) doesn't contain milliseconds and are therefor zero. Hence mTime <= bTime is false nearly every time.

For more information you can look into the [caching guide from google](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching?hl=en).