### PR TITLE
add `actionhero version` + allow `help` and `version` to be run outside of actionhero projects

### DIFF
--- a/bin/actionhero
+++ b/bin/actionhero
@@ -29,7 +29,7 @@ let commands = [];
 if(!optimist.argv._ || optimist.argv._.length === 0){ commands.push('start'); }
 optimist.argv._.forEach(function(arg){ commands.push(arg); });
 
-if(commands.length === 1 && commands[0] === 'generate'){
+if(commands.length === 1 && ['generate', 'help', 'version'].indexOf(commands[0]) >= 0){
 
   // when generating the project from scratch, we cannot rely on the normal initilizers
   const runner = require(__dirname + path.sep + 'methods' + path.sep + commands.join(path.sep) + '.js');

--- a/bin/methods/version.js
+++ b/bin/methods/version.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const fs = require('fs');
-
 module.exports = function(api, next){
   const packageJSON = require(__dirname + '/../../package.json');
   console.log(packageJSON.version);

--- a/bin/methods/version.js
+++ b/bin/methods/version.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const fs = require('fs');
+
+module.exports = function(api, next){
+  const packageJSON = require(__dirname + '/../../package.json');
+  console.log(packageJSON.version);
+  next(null, true);
+};

--- a/bin/methods/version.js
+++ b/bin/methods/version.js
@@ -1,7 +1,8 @@
 'use strict';
 
+const packageJSON = require(__dirname + '/../../package.json');
+
 module.exports = function(api, next){
-  const packageJSON = require(__dirname + '/../../package.json');
   console.log(packageJSON.version);
   next(null, true);
 };

--- a/test/core/binary.js
+++ b/test/core/binary.js
@@ -7,6 +7,7 @@ var path    = require('path');
 var exec    = require('child_process').exec;
 var testDir = os.tmpdir() + path.sep + 'actionheroTestProject';
 var binary  = './node_modules/.bin/actionhero';
+var pacakgeJSON = require(__dirname + '/../../package.json');
 
 var doBash = function(commands, callback){
   var fullCommand = '/bin/bash -c \'' + commands.join(' && ') + '\'';
@@ -114,6 +115,16 @@ describe('Core: Binary', function(){
         data.should.containEql('actionhero start cluster');
         data.should.containEql('Binary options:');
         data.should.containEql('actionhero generate server');
+        done();
+      });
+    });
+
+    it('can call the version command', function(done){
+      doBash([
+        'cd ' + testDir, binary + ' version'
+      ], function(error, data){
+        should.not.exist(error);
+        data.trim().should.equal(pacakgeJSON.version);
         done();
       });
     });


### PR DESCRIPTION
1) add `actionhero version` to return the version of ActionHero being used
2) When using a globally-installed version of actionhero, allow the following subset of commands to be used outside of an ActionHero project directory:
- `actionhero help`
- `actionhero generate`
- `actionhero version`

Other commands will remain crashing outside of an ActionHero project folder, as they will require config files.