### PR TITLE
Addressing if-modified-since issue on a 404

### DIFF
--- a/servers/web.js
+++ b/servers/web.js
@@ -125,17 +125,17 @@ const initialize = function(api, options, next){
         connection.rawConnection.res.end();
         connection.destroy();
       }
+    };
+
+    if (error) {
+      connection.rawConnection.responseHttpCode = 404;
+      return sendRequestResult();
     }
 
     if(reqHeaders['if-modified-since']){
       ifModifiedSince = new Date(reqHeaders['if-modified-since']);
       lastModified.setMilliseconds(0);
       if(lastModified <= ifModifiedSince){connection.rawConnection.responseHttpCode = 304; }
-      return sendRequestResult();
-    }
-
-    if(error){
-      connection.rawConnection.responseHttpCode = 404;
       return sendRequestResult();
     }
 

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -25,14 +25,14 @@ describe('Server: Web', function(){
   });
 
   it('file: 404 pages from POST with if-modified-since header', function(done) {
-    let file = Math.random().toString(36);
-    let options = {
+    var file = Math.random().toString(36);
+    var options = {
       url: url + '/' + file,
       headers: {
         'if-modified-since': 'Thu, 19 Apr 2012 09:51:20 GMT'
       }
     };
-    request.post(options, function(error, response, body) {
+    request.get(options, function(error, response, body) {
       should.not.exist(error);
       response.statusCode.should.equal(404);
       response.body.should.equal('That file is not found (' + file + ')');

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -24,6 +24,22 @@ describe('Server: Web', function(){
     });
   });
 
+  it('file: 404 pages from POST with if-modified-since header', function(done) {
+    let file = Math.random().toString(36);
+    let options = {
+      url: url + '/' + file,
+      headers: {
+        'if-modified-since': 'Thu, 19 Apr 2012 09:51:20 GMT'
+      }
+    };
+    request.post(options, function(error, response, body) {
+      should.not.exist(error);
+      response.statusCode.should.equal(404);
+      response.body.should.equal('That file is not found (' + file + ')');
+      done();
+    });
+  });
+
   it('Server should be up and return data', function(done){
     request.get(url + '/api/', function(error, response, body){
       should.not.exist(error);


### PR DESCRIPTION
This should resolve the issue for #962. 

I've included a test to reproduce, and within servers/web.js simply moved the if(error) statement above the if-modified-since if statement.

The issue seems to be a 404 file, with a If-Modified-Since header set. I originally thought it might be related to a POST method but it was directly related to the header being set. I just double checked GET and it works as expected. Because of that, in this pull request, you'll see the test using the POST method. 