### PR TITLE
configuration setting for logging file requests

### DIFF
--- a/config/api.js
+++ b/config/api.js
@@ -36,6 +36,8 @@ exports['default'] = {
       missingParamChecks: [null, '', undefined],
       // The default filetype to server when a user requests a directory
       directoryFileType : 'index.html',
+      // What log-level should we use for file requests?
+      fileRequestLogLevel: 'info',
       // The default priority level given to middleware of all types (action, connection, say, and task)
       defaultMiddlewarePriority : 100,
       // Which channel to use on redis pub/sub for RPC communication

--- a/initializers/staticFile.js
+++ b/initializers/staticFile.js
@@ -76,7 +76,7 @@ module.exports = {
 
       sendFileNotFound: function(connection, errorMessage, callback){
         connection.error = new Error(errorMessage);
-        this.logRequest('{404: not found}', connection, null, null, false);
+        this.logRequest('{not found}', connection, null, null, false);
         callback(connection, api.config.errors.fileNotFound(connection), null, 'text/html', api.config.errors.fileNotFound(connection).length);
       },
 
@@ -107,9 +107,10 @@ module.exports = {
       },
 
       logRequest: function(file, connection, length, duration, success){
-        api.log(['[ file @ %s ]', connection.type], 'debug', {
+        api.log(['[ file @ %s ]', connection.type], api.config.general.fileRequestLogLevel, {
           to: connection.remoteIP,
           file: file,
+          requestedFile: connection.params.file,
           size: length,
           duration: duration,
           success: success


### PR DESCRIPTION
Allow direct configuration of logs when serving files via `api.config.general.fileRequestLogLevel`.  Also show both the file on disk and the requested file path from the URL.