### PR TITLE
XSS Fixes

### DIFF
--- a/config/errors.js
+++ b/config/errors.js
@@ -92,7 +92,7 @@ exports['default'] = {
       // The body message to accompany 404 (file not found) errors regarding flat files
       // You may want to load in the contnet of 404.html or similar
       fileNotFound: function(connection){
-        return connection.localize(['That file is not found (%s)', connection.params.file]);
+        return connection.localize(['That file is not found (%s)']);
       },
 
       // user didn't request a file

--- a/config/errors.js
+++ b/config/errors.js
@@ -92,7 +92,7 @@ exports['default'] = {
       // The body message to accompany 404 (file not found) errors regarding flat files
       // You may want to load in the contnet of 404.html or similar
       fileNotFound: function(connection){
-        return connection.localize(['That file is not found (%s)']);
+        return connection.localize(['That file is not found']);
       },
 
       // user didn't request a file

--- a/servers/web.js
+++ b/servers/web.js
@@ -383,7 +383,7 @@ const initialize = function(api, options, next){
         stringResponse = JSON.stringify(data.response, null, api.config.servers.web.padding);
         if(data.params.callback){
           data.connection.rawConnection.responseHeaders.push(['Content-Type', 'application/javascript']);
-          stringResponse = data.connection.params.callback + '(' + stringResponse + ');';
+          stringResponse = callbackHtmlEscape(data.connection.params.callback) + '(' + stringResponse + ');';
         }
       }else{
         stringResponse = data.response;
@@ -586,6 +586,17 @@ const initialize = function(api, options, next){
 
   next(server);
 };
+
+function callbackHtmlEscape(str){
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\)/g, '')
+    .replace(/\(/g, '');
+}
 
 /////////////////////////////////////////////////////////////////////
 // exports

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -24,7 +24,7 @@ describe('Core: i18n', function(){
 
     var spanish = {
       'Your random number is %s': 'Su número aleatorio es %s',
-      'That file is not found (%s)': 'Ese archivo no se encuentra (%s)',
+      'That file is not found': 'Ese archivo no se encuentra',
       '%s is a required parameter for this action': '%s es un parámetro requerido para esta acción',
     };
     fs.writeFileSync(tmpPath + 'es.json', JSON.stringify(spanish));

--- a/test/core/specHelper.js
+++ b/test/core/specHelper.js
@@ -84,7 +84,7 @@ describe('Core: specHelper', function(){
 
     it('missing files', function(done){
       api.specHelper.getStaticFile('missing.html', function(data){
-        data.error.should.equal('That file is not found (missing.html)');
+        data.error.should.equal('That file is not found');
         data.mime.should.equal('text/html');
         should.not.exist(data.content);
         done();

--- a/test/core/staticFile.js
+++ b/test/core/staticFile.js
@@ -31,7 +31,7 @@ describe('Core: Static File', function(){
 
   it('file: 404 pages', function(done){
     api.specHelper.getStaticFile('someRandomFile', function(response){
-      response.error.should.equal('That file is not found (someRandomFile)');
+      response.error.should.equal('That file is not found');
       should.not.exist(response.content);
       done();
     });
@@ -39,7 +39,7 @@ describe('Core: Static File', function(){
 
   it('I should not see files outside of the public dir', function(done){
     api.specHelper.getStaticFile('../config/config.json', function(response){
-      response.error.should.equal('That file is not found (../config/config.json)');
+      response.error.should.equal('That file is not found');
       should.not.exist(response.content);
       done();
     });

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -36,7 +36,7 @@ describe('Server: Web', function(){
     request.get(options, function(error, response, body){
       should.not.exist(error);
       response.statusCode.should.equal(404);
-      response.body.should.equal('That file is not found (' + file + ')');
+      response.body.should.equal('That file is not found');
       done();
     });
   });
@@ -211,6 +211,25 @@ describe('Server: Web', function(){
       });
     });
 
+  });
+
+  describe('JSONp', function(){
+    it('can ask for JSONp responses', function(done){
+      request.get(url + '/api/randomNumber?callback=myCallback', function(error, response, body){
+        should.not.exist(error);
+        body.indexOf('myCallback({').should.equal(0);
+        done();
+      });
+    });
+
+    it('JSONp responses cannot be used for XSS', function(done){
+      request.get(url + '/api/randomNumber?callback=alert(%27hi%27);foo', function(error, response, body){
+        should.not.exist(error);
+        body.should.not.containEql('alert({');
+        body.indexOf('alert&#39;hi&#39;;foo(').should.equal(0);
+        done();
+      });
+    });
   });
 
   it('gibberish actions have the right response', function(done){
@@ -608,7 +627,7 @@ describe('Server: Web', function(){
       request.get(url + '/public/../config.json', function(error, response){
         should.not.exist(error);
         response.statusCode.should.equal(404);
-        response.body.should.equal('That file is not found (..' + path.sep + 'config.json)');
+        response.body.should.equal('That file is not found');
         done();
       });
     });

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -619,6 +619,7 @@ describe('Server: Web', function(){
       request.get(url + '/public/notARealFile', function(error, response){
         should.not.exist(error);
         response.statusCode.should.equal(404);
+        response.statusCode.should.not.containEql('notARealFile');
         done();
       });
     });

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -619,7 +619,7 @@ describe('Server: Web', function(){
       request.get(url + '/public/notARealFile', function(error, response){
         should.not.exist(error);
         response.statusCode.should.equal(404);
-        response.statusCode.should.not.containEql('notARealFile');
+        response.body.should.not.containEql('notARealFile');
         done();
       });
     });

--- a/test/servers/websocket.js
+++ b/test/servers/websocket.js
@@ -148,7 +148,7 @@ describe('Server: Web Socket', function(){
 
     it('missing files', function(done){
       clientA.file('missing.html', function(data){
-        data.error.should.equal('That file is not found (missing.html)');
+        data.error.should.equal('That file is not found');
         data.mime.should.equal('text/html');
         should.not.exist(data.content);
         done();


### PR DESCRIPTION
Solves the following:

## 404 Web Request with malicious file name
Previously, the default error responder when a client asked for a static-file which was missing (404) returned the name the of that file
```js
api.config.errors.fileNotFound = function(connection){
  return connection.localize(['That file is not found (%s)', connection.params.file]);
}
```
This is dangerous because a malicious actor could request a filename with an executable javascript tag and harm the requester.   We now will no longer return the file name:
```js
api.config.errors.fileNotFound = function(connection){
  return connection.localize(['That file is not found']);
}
```

## Malicious callback provided when requesting an action via JSONp
When requesting an action via JSONp, it was possible (though unlikely) that the `callback` string you were providing contained malicious javascript which would harm the requester.  We will now sanitize the provided `callback` in the following way:
```javascript
function callbackHtmlEscape(str){
  return str
    .replace(/&/g, '&amp;')
    .replace(/"/g, '&quot;')
    .replace(/'/g, '&#39;')
    .replace(/</g, '&lt;')
    .replace(/>/g, '&gt;')
    .replace(/\)/g, '')
    .replace(/\(/g, '');
}
```

---

A huge thank you to @submitteddenied is earned for reporting these issues and working to fix them.