### PR TITLE
HTTP Client Redirection

### DIFF
--- a/config/servers/web.js
+++ b/config/servers/web.js
@@ -11,6 +11,8 @@ exports['default'] = {
         secure: false,
         // Passed to https.createServer if secure=true. Should contain SSL certificates
         serverOptions: {},
+        // Should we redirect all traffic to the first host in this array if hte request header doesn't match?
+        allowedRequestHosts: process.env.ALLOWED_HOSTS ? process.env.ALLOWED_HOSTS.split(',') : [],
         // Port or Socket Path
         port: process.env.PORT || 8080,
         // Which IP to listen on (use '0.0.0.0' for all; '::' for all on ipv4 and ipv6)

--- a/docs/_includes/docs/servers/web.html
+++ b/docs/_includes/docs/servers/web.html
@@ -345,7 +345,7 @@ get: [
 
   <h4>Hosts</h4>
 
-  ActionHero allows you to define a collection of host headers which this API server will allow access from.  You can set these via `api.config.servers.web.allowedRequestHosts`.  If the `Host` header of a client does not match one of those listed (proticol counts!), they will be redirected to the first one present.
+  ActionHero allows you to define a collection of host headers which this API server will allow access from.  You can set these via `api.config.servers.web.allowedRequestHosts`.  If the `Host` header of a client does not match one of those listed (protocol counts!), they will be redirected to the first one present.
 
   <h4>Route Notes</h4>
 

--- a/docs/_includes/docs/servers/web.html
+++ b/docs/_includes/docs/servers/web.html
@@ -343,6 +343,10 @@ get: [
   <p>After mapping this route all files/folders within the mapped folder will be accessible on the route.</p>
   <p>You have to map the specified public folder within the "dir" parameter, relative to the routes.js file or absolute. Make sure to set "matchTrailingPathParts" to "true", because when it is set to false, the route will never match when you request a file. (e.g.: site.com/my/special/folder/testfile.txt).</p>
 
+  <h4>Hosts</h4>
+
+  ActionHero allows you to define a collection of host headers which this API server will allow access from.  You can set these via `api.config.servers.web.allowedRequestHosts`.  If the `Host` header of a client does not match one of those listed (proticol counts!), they will be redirected to the first one present.
+
   <h4>Route Notes</h4>
 
   <ul>

--- a/docs/_includes/docs/servers/web.html
+++ b/docs/_includes/docs/servers/web.html
@@ -345,7 +345,9 @@ get: [
 
   <h4>Hosts</h4>
 
-  ActionHero allows you to define a collection of host headers which this API server will allow access from.  You can set these via `api.config.servers.web.allowedRequestHosts`.  If the `Host` header of a client does not match one of those listed (protocol counts!), they will be redirected to the first one present.
+  <p>ActionHero allows you to define a collection of host headers which this API server will allow access from.  You can set these via `api.config.servers.web.allowedRequestHosts`.  If the `Host` header of a client does not match one of those listed (protocol counts!), they will be redirected to the first one present.</p>
+  <p>You can also set `process.env.ALLOWED_HOSTS` which will be parsed as a comma-separated list of Hosts which will set `api.config.servers.web.allowedRequestHosts`</p>
+
 
   <h4>Route Notes</h4>
 

--- a/servers/web.js
+++ b/servers/web.js
@@ -313,6 +313,16 @@ const initialize = function(api, options, next){
         }
       }
 
+      if(api.config.servers.web.allowedRequestHosts && api.config.servers.web.allowedRequestHosts.length > 0){
+        let fullRequestHost = (req.uri.protocol ? (req.uri.protocol + ':') : '') + req.headers.host;
+        if(api.config.servers.web.allowedRequestHosts.indexOf(fullRequestHost) < 0){
+          let newHost = api.config.servers.web.allowedRequestHosts[0];
+          res.statusCode = 302;
+          res.setHeader('Location', newHost);
+          return res.end('You are being redirected to ' + newHost + '\r\n');
+        }
+      }
+
       server.buildConnection({
         // will emit 'connection'
         rawConnection: {

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -236,6 +236,37 @@ describe('Server: Web', function(){
     });
   });
 
+  describe('request redirecton (allowedRequestHosts)', function(){
+    before(function(){ api.config.servers.web.allowedRequestHosts = ['https://www.site.com']; });
+    after(function(){ api.config.servers.web.allowedRequestHosts = []; });
+
+    it('will redirect clients if they do not request the proper host', function(done){
+      request.get({
+        followRedirect: false,
+        url: url + '/api/randomNumber',
+        headers: {'Host': 'http://www.site.com'}
+      }, function(error, response, body){
+        should.not.exist(error);
+        response.headers.location.should.equal('https://www.site.com');
+        body.should.containEql('You are being redirected to https://www.site.com');
+        done();
+      });
+    });
+
+    it('will allow API access from the proper hosts', function(done){
+      request.get({
+        followRedirect: false,
+        url: url + '/api/randomNumber',
+        headers: {'Host': 'https://www.site.com'}
+      }, function(error, response, body){
+        should.not.exist(error);
+        should.not.exist(response.headers.location);
+        body.should.containEql('randomNumber');
+        done();
+      });
+    });
+  });
+
   it('gibberish actions have the right response', function(done){
     request.get(url + '/api/IAMNOTANACTION', function(error, response, body){
       should.not.exist(error);


### PR DESCRIPTION
ActionHero now allows you to define a collection of host headers which this API server will allow access from.  You can set these via `api.config.servers.web.allowedRequestHosts`.  If the `Host` header of a client does not match one of those listed (protocol counts!), they will be redirected to the first one present.

You can also set `process.env.ALLOWED_HOSTS` which will be parsed as a comma-separated list of Hosts which will set `api.config.servers.web.allowedRequestHosts`