### PR TITLE
Do not localize log messages by default; add option to do so

### DIFF
--- a/config/logger.js
+++ b/config/logger.js
@@ -41,6 +41,9 @@ exports['default'] = {
     // the maximum length of param to log (we will truncate)
     logger.maxLogStringLength = 100;
 
+    // should system logs (api.log) be localized?
+    logger.localizeLogMessages = false;
+
     // you can optionally set custom log levels
     // logger.levels = {good: 0, bad: 1};
 

--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const util = require('util');
 const winston = require('winston');
 
 module.exports = {
@@ -30,7 +31,16 @@ module.exports = {
     }
 
     api.log = function(message, severity, data){
-      let localizedMessage = api.i18n.localize(message);
+
+      let localizedMessage;
+      if(api.config.logger.localizeLogMessages === true){
+        localizedMessage = api.i18n.localize(message);
+      }else if(typeof message === 'string'){
+        localizedMessage = message;
+      }else{
+        localizedMessage = util.format.apply(this, message);
+      }
+
       if(severity === undefined || severity === null || api.logger.levels[severity] === undefined){ severity = 'info'; }
       let args = [severity, localizedMessage];
       if(data !== null && data !== undefined){ args.push(data); }

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -46,15 +46,11 @@ describe('Core: i18n', function(){
     });
   });
 
-  it('should create localization files by default, and strings from actions and the server should be included automatically', function(done){
+  it('should create localization files by default, and strings from actions should be included', function(done){
     api.specHelper.runAction('randomNumber', function(response){
       response.randomNumber.should.be.within(0, 1);
       var content = readLocaleFile();
       [
-        '*** Starting ActionHero ***',
-        'Loaded initializer: %s',
-        '*** ActionHero Started ***',
-        '[ action @ %s ]',
         'Your random number is %s',
       ].forEach(function(s){
         should.exist(content[s]);


### PR DESCRIPTION
solves https://github.com/evantahler/actionhero/issues/974

Creates a new config option `api.config.logger.localizeLogMessages` which allows developers to opt-into localizing all system log messages (`api.log`).  

The default changes in this pull request from the previous "enabled implicitly" to "disabled explicitly" 
