### PR TITLE
Response type saftey for action errors and spec helper

### DIFF
--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -74,8 +74,13 @@ module.exports = {
       if(error && typeof error === 'string'){
         error = new Error(error);
       }
+
       if(error && !this.response.error){
-        this.response.error = error;
+        if(typeof this.response === 'string' || Array.isArray(this.response)){
+          this.response = error.toString();
+        }else{
+          this.response.error = error;
+        }
       }
 
       this.incrementPendingActions(-1);

--- a/test/core/specHelper.js
+++ b/test/core/specHelper.js
@@ -91,15 +91,15 @@ describe('Core: specHelper', function(){
       });
     });
 
-    // it('if the response payload is a array, just the error will be returned', function(done){
-    //   api.specHelper.runAction('arrayErrorTestAction', function(response){
-    //     response.should.equal('Error: some error');
-    //     should.not.exist(response.messageCount);
-    //     should.not.exist(response.serverInformation);
-    //     should.not.exist(response.requesterInformation);
-    //     done();
-    //   });
-    // });
+    it('if the response payload is a array, just the error will be returned', function(done){
+      api.specHelper.runAction('arrayErrorTestAction', function(response){
+        response.should.equal('Error: some error');
+        should.not.exist(response.messageCount);
+        should.not.exist(response.serverInformation);
+        should.not.exist(response.requesterInformation);
+        done();
+      });
+    });
   });
 
   describe('test callbacks', function(){

--- a/test/core/specHelper.js
+++ b/test/core/specHelper.js
@@ -35,8 +35,21 @@ describe('Core: specHelper', function(){
     });
   });
 
-  describe('metadata and errors', function(){
+  describe('metadata, type-saftey, and errors', function(){
     before(function(){
+      api.actions.versions.stringResponseTestAction = [1];
+      api.actions.actions.stringResponseTestAction = {
+        '1': {
+          name: 'stringResponseTestAction',
+          description: 'stringResponseTestAction',
+          version: 1,
+          run:function(api, data, next){
+            data.response = 'something response';
+            next();
+          }
+        }
+      };
+
       api.actions.versions.stringErrorTestAction = [1];
       api.actions.actions.stringErrorTestAction = {
         '1': {
@@ -44,8 +57,21 @@ describe('Core: specHelper', function(){
           description: 'stringErrorTestAction',
           version: 1,
           run:function(api, data, next){
-            data.response = 'something here';
+            data.response = 'something response';
             next('some error');
+          }
+        }
+      };
+
+      api.actions.versions.arrayResponseTestAction = [1];
+      api.actions.actions.arrayResponseTestAction = {
+        '1': {
+          name: 'arrayResponseTestAction',
+          description: 'arrayResponseTestAction',
+          version: 1,
+          run:function(api, data, next){
+            data.response = [1, 2, 3];
+            next();
           }
         }
       };
@@ -65,39 +91,81 @@ describe('Core: specHelper', function(){
     });
 
     after(function(){
+      delete api.actions.actions.stringResponseTestAction;
+      delete api.actions.versions.stringResponseTestAction;
       delete api.actions.actions.stringErrorTestAction;
       delete api.actions.versions.stringErrorTestAction;
+      delete api.actions.actions.arrayResponseTestAction;
+      delete api.actions.versions.arrayResponseTestAction;
       delete api.actions.actions.arrayErrorTestAction;
       delete api.actions.versions.arrayErrorTestAction;
     });
 
-    it('if the response payload is an object, it will append serverInformation, requesterInformation, and messageCount', function(done){
-      api.specHelper.runAction('x', function(response){
-        response.error.should.equal('Error: unknown action or invalid apiVersion');
-        response.messageCount.should.equal(1);
-        response.serverInformation.serverName.should.equal('actionhero');
-        response.requesterInformation.remoteIP.should.equal('testServer');
-        done();
+    describe('happy-path', function(){
+      it('if the response payload is an object, it appends metadata', function(done){
+        api.specHelper.runAction('randomNumber', function(response){
+          should.not.exist(response.error);
+          should.exist(response.randomNumber);
+          response.messageCount.should.equal(1);
+          response.serverInformation.serverName.should.equal('actionhero');
+          response.requesterInformation.remoteIP.should.equal('testServer');
+          done();
+        });
+      });
+
+      it('if the response payload is a string, it maintains type', function(done){
+        api.specHelper.runAction('stringResponseTestAction', function(response){
+          response.should.deepEqual('something response');
+          should.not.exist(response.error);
+          should.not.exist(response.messageCount);
+          should.not.exist(response.serverInformation);
+          should.not.exist(response.requesterInformation);
+          done();
+        });
+      });
+
+      it('if the response payload is a array, it maintains type', function(done){
+        api.specHelper.runAction('arrayResponseTestAction', function(response){
+          response.should.deepEqual([1, 2, 3]);
+          should.not.exist(response.error);
+          should.not.exist(response.messageCount);
+          should.not.exist(response.serverInformation);
+          should.not.exist(response.requesterInformation);
+          done();
+        });
       });
     });
 
-    it('if the response payload is a string, just the error will be returned', function(done){
-      api.specHelper.runAction('stringErrorTestAction', function(response){
-        response.should.equal('Error: some error');
-        should.not.exist(response.messageCount);
-        should.not.exist(response.serverInformation);
-        should.not.exist(response.requesterInformation);
-        done();
-      });
-    });
+    describe('errors', function(){
 
-    it('if the response payload is a array, just the error will be returned', function(done){
-      api.specHelper.runAction('arrayErrorTestAction', function(response){
-        response.should.equal('Error: some error');
-        should.not.exist(response.messageCount);
-        should.not.exist(response.serverInformation);
-        should.not.exist(response.requesterInformation);
-        done();
+      it('if the response payload is an object and there is an error, it appends metadata', function(done){
+        api.specHelper.runAction('x', function(response){
+          response.error.should.equal('Error: unknown action or invalid apiVersion');
+          response.messageCount.should.equal(1);
+          response.serverInformation.serverName.should.equal('actionhero');
+          response.requesterInformation.remoteIP.should.equal('testServer');
+          done();
+        });
+      });
+
+      it('if the response payload is a string, just the error will be returned', function(done){
+        api.specHelper.runAction('stringErrorTestAction', function(response){
+          response.should.equal('Error: some error');
+          should.not.exist(response.messageCount);
+          should.not.exist(response.serverInformation);
+          should.not.exist(response.requesterInformation);
+          done();
+        });
+      });
+
+      it('if the response payload is a array, just the error will be returned', function(done){
+        api.specHelper.runAction('arrayErrorTestAction', function(response){
+          response.should.equal('Error: some error');
+          should.not.exist(response.messageCount);
+          should.not.exist(response.serverInformation);
+          should.not.exist(response.requesterInformation);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
If your action returns a `string` or `array`,  and there is an error, we should return the error as a string, and not attempt to return `response.error = error`, as this creates an improper javascript object. 

This extends to the specHelper, whose response types should follow this same pattern.  Actions with string responses will remain as string responses (and arrays). 