### PR TITLE
api.specHelper.returnMetadata to enable/disable spec helper metadata

### DIFF
--- a/docs/_includes/docs/deployment/testing.html
+++ b/docs/_includes/docs/deployment/testing.html
@@ -141,5 +141,6 @@ api.specHelper.runTask(‘sendEmailTask', {message: ‘hello' to: ‘evan@test.c
 
   <h2 id="testing-notes">Notes</h2>
   <p>Be sure to run your tests in the <code>test</code> environment, setting the shell's env with <code>NODE_ENV=test</code>.  You can alternatively set this explicitly in your tests with <code>process.env.NODE_ENV = 'test'</code></p>
+  <p>If you do not want the <code>specHelper</code> actions to include metadata (<code>data.response.serverInformation</code>, <code>data.response.requesterInformation</code>, and <code>data.response.messageCount</code>) from the server, you can configure <code>api.specHelper.returnMetadata = false</code> in your tests.</p>
 
 </section>

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -10,7 +10,9 @@ module.exports = {
 
     if(api.env === 'test' || process.env.SPECHELPER === 'true' || process.env.SPECHELPER === true){
 
-      api.specHelper = {};
+      api.specHelper = {
+        returnMetadata: true,
+      };
 
       // create a test 'server' to run actions
       api.specHelper.initialize = function(api, options, next){
@@ -36,10 +38,6 @@ module.exports = {
 
         server.sendMessage = function(connection, message, messageCount){
           process.nextTick(() => {
-            if(typeof message !== 'string' && !Array.isArray(message)){
-              message.messageCount = messageCount;
-            }
-
             connection.messages.push(message);
             if(typeof connection.actionCallbacks[messageCount] === 'function'){
               connection.actionCallbacks[messageCount](message, connection);
@@ -92,21 +90,23 @@ module.exports = {
               data.response.error = api.config.errors.serializers.servers.specHelper(data.response.error);
             }
 
-            data.response.messageCount = data.messageCount;
+            if(api.specHelper.returnMetadata){
+              data.response.messageCount = data.messageCount;
 
-            data.response.serverInformation = {
-              serverName: api.config.general.serverName,
-              apiVersion: api.config.general.apiVersion,
-            };
+              data.response.serverInformation = {
+                serverName: api.config.general.serverName,
+                apiVersion: api.config.general.apiVersion,
+              };
 
-            data.response.requesterInformation = {
-              id: data.connection.id,
-              remoteIP: data.connection.remoteIP,
-              receivedParams: {}
-            };
+              data.response.requesterInformation = {
+                id: data.connection.id,
+                remoteIP: data.connection.remoteIP,
+                receivedParams: {}
+              };
 
-            for(let k in data.params){
-              data.response.requesterInformation.receivedParams[k] = data.params[k];
+              for(let k in data.params){
+                data.response.requesterInformation.receivedParams[k] = data.params[k];
+              }
             }
           }
 

--- a/test/core/specHelper.js
+++ b/test/core/specHelper.js
@@ -136,6 +136,22 @@ describe('Core: specHelper', function(){
       });
     });
 
+    describe('disabling metadata', function(){
+      before(function(){ api.specHelper.returnMetadata = false; });
+      after(function(){ api.specHelper.returnMetadata = true; });
+
+      it('if the response payload is an object, it should not append metadata', function(done){
+        api.specHelper.runAction('randomNumber', function(response){
+          should.not.exist(response.error);
+          should.exist(response.randomNumber);
+          should.not.exist(response.messageCount);
+          should.not.exist(response.serverInformation);
+          should.not.exist(response.requesterInformation);
+          done();
+        });
+      });
+    });
+
     describe('errors', function(){
 
       it('if the response payload is an object and there is an error, it appends metadata', function(done){


### PR DESCRIPTION
In your tests, if you do not want the `specHelper` actions to include metadata (`data.response.serverInformation`, `data.response.requesterInformation`, and `data.response.messageCount`) from the server, you can configure `api.specHelper.returnMetadata = false` in your tests.</p>
