### PR TITLE
Remove "uncaught" from error message

### DIFF
--- a/initializers/exceptions.js
+++ b/initializers/exceptions.js
@@ -28,7 +28,7 @@ module.exports = {
           }
         }
       }else if(type === 'task'){
-        extraMessages.push('! uncaught error from task: ' + name + ' on queue ' + objects.queue + ' (worker #' + objects.workerId + ')');
+        extraMessages.push('! error from task: ' + name + ' on queue ' + objects.queue + ' (worker #' + objects.workerId + ')');
         try{
           extraMessages.push('!     arguments: ' + JSON.stringify(objects.task.args));
         }catch(e){}


### PR DESCRIPTION
 Remove "uncaught" from error message since the error has actually been caught.