### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 module.exports = {
   loadPriority:  400,

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid  = require('node-uuid');
+const uuid  = require('uuid');
 const async = require('async');
 
 module.exports = {

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const NR = require('node-resque');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "is-running": "^2.0.1",
     "mime": "^1.3.4",
     "node-resque": "^4.0.1",
-    "node-uuid": "^1.4.4",
     "optimist": "^0.6.1",
     "primus": "^6.0.2",
     "qs": "^6.0.1",
     "uglify-js": "^2.7.2",
+    "uuid": "^3.0.0",
     "winston": "^2.0.0",
     "ws": "^1.1.1"
   },

--- a/servers/web.js
+++ b/servers/web.js
@@ -8,7 +8,7 @@ const zlib                = require('zlib');
 const formidable          = require('formidable');
 const browser_fingerprint = require('browser_fingerprint');
 const Mime                = require('mime');
-const uuid                = require('node-uuid');
+const uuid                = require('uuid');
 const etag                = require('etag');
 
 const initialize = function(api, options, next){

--- a/test/servers/socket.js
+++ b/test/servers/socket.js
@@ -1,5 +1,5 @@
 var should = require('should');
-var uuid   = require('node-uuid');
+var uuid   = require('uuid');
 var actionheroPrototype = require(__dirname + '/../../actionhero.js').actionheroPrototype;
 var actionhero = new actionheroPrototype();
 var api;

--- a/test/zzz_benchmarks/benchmarks.js
+++ b/test/zzz_benchmarks/benchmarks.js
@@ -1,6 +1,6 @@
 var actionheroPrototype = require(__dirname + '/../../actionhero.js').actionheroPrototype;
 var actionhero = new actionheroPrototype();
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var api;
 var messages = [];
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.