### PR TITLE
Fixes socket helper functions

### DIFF
--- a/servers/web.js
+++ b/servers/web.js
@@ -584,7 +584,7 @@ const initialize = function (api, options, next) {
   }
 
   const chmodSocket = function (bindIP, port) {
-    if (!options.bindIP && options.port.indexOf('/') >= 0) {
+    if (!bindIP && port.indexOf('/') >= 0) {
       fs.chmodSync(port, '0777')
     }
   }

--- a/servers/web.js
+++ b/servers/web.js
@@ -572,7 +572,7 @@ const initialize = function (api, options, next) {
   }
 
   const cleanSocket = function (bindIP, port) {
-    if (!bindIP && port.indexOf('/') >= 0) {
+    if (!bindIP && typeof port === 'string' && port.indexOf('/') >= 0) {
       fs.unlink(port, (error) => {
         if (error) {
           server.log('cannot remove stale socket @' + port + ' : ' + error)
@@ -584,7 +584,7 @@ const initialize = function (api, options, next) {
   }
 
   const chmodSocket = function (bindIP, port) {
-    if (!bindIP && port.indexOf('/') >= 0) {
+    if (!bindIP && typeof port === 'string' && port.indexOf('/') >= 0) {
       fs.chmodSync(port, '0777')
     }
   }


### PR DESCRIPTION
`chmodSocket` was pulling in external `options` rather than using passed in parameters.

`cleanSocket` and `chmodSocket` both assumed `port` to be a string.  While this _should_ be the case, there are no prior checks for this condition so the error thrown is quite confusing for the end user.  The code has been modified to check that the `port` is a string type before calling `indexOf` on it.

A check of the `port` and `bindIp` attributes should occur somewhere prior to this point and an error thrown.  By default the web test config overrides the `port`, but not the `bindIp`, so an environment configured to use a socket for connections will get an error when running tests unless they know to override the `port` for the test config as well.